### PR TITLE
Fix rating update script

### DIFF
--- a/scripts/update_title_ratings.py
+++ b/scripts/update_title_ratings.py
@@ -1,10 +1,11 @@
 import csv
 import logging
 import os
+import asyncio
 
-from config import Config, DatabaseConnection
+from config import Config, DatabaseConnectionPool
 
-dbconfig = Config.STACKHERO_DB_CONFIG
+dbconfig = Config.get_db_config()
 
 # Use os.path.dirname to go up one level from the current script's directory
 # Use os.path.dirname to go up one level from the current script's directory
@@ -17,64 +18,52 @@ os.chdir(parent_dir)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 
-def read_tsv_and_update_database(tsv_file_path, db_connection):
-    """
-    Reads a TSV file and updates the averageRating and numVotes in the database.
-    Logs each update operation.
+async def read_tsv_and_update_database(tsv_file_path, db_pool):
+    """Read a TSV file and update ratings in the database asynchronously."""
+    connection = await db_pool.get_async_connection()
+    if not connection:
+        logging.error("Failed to acquire database connection.")
+        return
 
-    :param tsv_file_path: Path to the TSV file containing the updates.
-    :param db_connection: DatabaseConnection instance for DB operations.
-    """
     try:
-        # Establish a database connection
-        connection = db_connection.create_sync_connection()
-        if not connection:
-            logging.error("Failed to establish database connection.")
-            return
-
-        logging.info("Successfully connected to database.")
-
-        with connection.cursor() as cursor:
-            # Open the TSV file for reading
-            with open(tsv_file_path, 'r', encoding='utf-8') as tsvfile:
-                reader = csv.DictReader(tsvfile, delimiter='\t')
+        async with connection.cursor() as cursor:
+            with open(tsv_file_path, "r", encoding="utf-8") as tsvfile:
+                reader = csv.DictReader(tsvfile, delimiter="\t")
                 for row in reader:
-                    # Extract data from the current row
-                    tconst = row['tconst']
-                    averageRating = row['averageRating']
-                    numVotes = row['numVotes']
+                    tconst = row["tconst"]
+                    averageRating = row["averageRating"]
+                    numVotes = row["numVotes"]
 
-                    # Prepare the UPDATE statement
                     update_sql = """
                     UPDATE `title.ratings`
                     SET `averageRating` = %s, `numVotes` = %s
                     WHERE `tconst` = %s
                     """
 
-                    # Log the update operation
-                    logging.info(f"Updating {tconst} with averageRating {averageRating} and numVotes {numVotes}.")
+                    logging.info(
+                        f"Updating {tconst} with averageRating {averageRating} and numVotes {numVotes}."
+                    )
+                    await cursor.execute(update_sql, (averageRating, numVotes, tconst))
 
-                    # Execute the update query
-                    cursor.execute(update_sql, (averageRating, numVotes, tconst))
-
-                # Commit the changes to the database
-                connection.commit()
-                logging.info("Database updated successfully.")
-
+            await connection.commit()
+            logging.info("Database updated successfully.")
     except Exception as e:
         logging.error(f"An error occurred: {e}")
     finally:
-        if connection:
-            # Make sure to close the database connection
-            connection.close()
-            logging.info("Database connection closed.")
+        await db_pool.release_async_connection(connection)
+        logging.info("Database connection released.")
 
 
 # Path to your TSV file - ensure this path is correct
-tsv_file_path = 'scripts/title.ratings.tsv'  # Update this path as necessary
+tsv_file_path = "scripts/title.ratings.tsv"  # Update this path as necessary
 
-# Initialize the DatabaseConnection with the STACKHERO_DB_CONFIG
-db_connection = DatabaseConnection(Config.STACKHERO_DB_CONFIG)
 
-# Call the function with the path to your TSV file and the database connection instance
-read_tsv_and_update_database(tsv_file_path, db_connection)
+async def main() -> None:
+    db_pool = DatabaseConnectionPool(dbconfig)
+    await db_pool.init_pool()
+    await read_tsv_and_update_database(tsv_file_path, db_pool)
+    await db_pool.close_pool()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- rework `update_title_ratings` to use `DatabaseConnectionPool`
- adapt script for async connections using the pool

## Testing
- `pytest -q` *(fails: duplicate base class TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_688ad83cbfa8832dbb840bfc5cd9fd1b