### PR TITLE
Fix MovieQueue synchronization and task tracking

### DIFF
--- a/movie_service.py
+++ b/movie_service.py
@@ -212,7 +212,7 @@ class MovieManager:
             current_displayed_movie = future_stack.pop()
         elif not user_queue.empty():
             logging.info(f"Pulling movie from movie queue for user_id: {user_id}")
-            current_displayed_movie = await user_queue.get()
+            current_displayed_movie = await self.movie_queue_manager.dequeue_movie(user_id)
 
         # If there is a currently displayed movie, push it to the previous stack
         if (


### PR DESCRIPTION
## Summary
- make per-user space_available events
- avoid busy wait and signal producers when consuming
- allow checking running tasks per-user
- consume queue items via MovieQueue.dequeue_movie

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b3e1c1d14832db53ff879c75b64dc