### PR TITLE
Add tests for additional modules

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,23 +1,15 @@
-import pytest
-from quart import Quart
+import asyncio
 from app import create_app
 
-@pytest.fixture
-async def app() -> Quart:
-    # Create an instance of the Quart application
-    app = create_app()
-    async with app.app_context():
-        # Yield the app instance in an async context
-        yield app
 
-@pytest.fixture
-async def client(app):
-    # Return the test client directly
-    return app.test_client()
+def test_home():
+    """Ensure the home route returns HTTP 200."""
 
-@pytest.mark.asyncio
-async def test_home(client):
-    # Directly use the client fixture to make a request
-    response = await client.get("/")
-    assert response.status_code == 200
-    # Additional assertions as needed
+    async def run_test():
+        app = create_app()
+        async with app.app_context():
+            client = app.test_client()
+            response = await client.get("/")
+            assert response.status_code == 200
+
+    asyncio.run(run_test())

--- a/tests/test_filter_backend_extract.py
+++ b/tests/test_filter_backend_extract.py
@@ -1,0 +1,47 @@
+import pytest
+from scripts.filter_backend import extract_movie_filter_criteria
+
+
+class DummyForm:
+    """Simple stand-in for a web form object."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def getlist(self, key):
+        return self._data.get(key, [])
+
+
+def test_default_language_is_english():
+    form = DummyForm({'year_min': '2000', 'year_max': '2005'})
+    criteria = extract_movie_filter_criteria(form)
+    assert criteria['min_year'] == 2000
+    assert criteria['max_year'] == 2005
+    assert criteria['language'] == 'en'
+
+
+def test_extract_all_fields():
+    form = DummyForm({
+        'year_min': '1990',
+        'year_max': '1995',
+        'imdb_score_min': '7.1',
+        'imdb_score_max': '8.5',
+        'num_votes_min': '100',
+        'num_votes_max': '1000',
+        'language': 'fr',
+        'genres[]': ['Action', 'Drama']
+    })
+    criteria = extract_movie_filter_criteria(form)
+    assert criteria == {
+        'min_year': 1990,
+        'max_year': 1995,
+        'min_rating': 7.1,
+        'max_rating': 8.5,
+        'min_votes': 100,
+        'max_votes': 1000,
+        'genres': ['Action', 'Drama'],
+        'language': 'fr'
+    }

--- a/tests/test_movie_queue.py
+++ b/tests/test_movie_queue.py
@@ -1,0 +1,33 @@
+import asyncio
+from scripts.movie_queue import MovieQueue
+
+
+class DummyFetcher:
+    async def fetch_random_movies15(self, criteria):
+        return []
+
+
+def test_get_user_queue_and_stop_flag():
+    async def run_test():
+        queue = asyncio.Queue()
+        mq = MovieQueue(db_config=None, queue=queue, movie_fetcher=DummyFetcher())
+        user_queue = await mq.get_user_queue('u1')
+        assert 'u1' in mq.user_queues
+        assert isinstance(user_queue, asyncio.Queue)
+        await mq.set_stop_flag('u1', True)
+        assert await mq.check_stop_flag('u1') is True
+
+    asyncio.run(run_test())
+
+
+def test_is_task_running():
+    async def run_test():
+        mq = MovieQueue(db_config=None, queue=asyncio.Queue(), movie_fetcher=DummyFetcher())
+        assert mq.is_task_running('u1') is False
+        task = asyncio.create_task(asyncio.sleep(0))
+        mq.user_queues['u1'] = {'populate_task': task}
+        assert mq.is_task_running('u1') is True
+        await task
+        assert mq.is_task_running('u1') is False
+
+    asyncio.run(run_test())

--- a/tests/test_movie_service.py
+++ b/tests/test_movie_service.py
@@ -1,83 +1,67 @@
-import pytest
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 from movie_service import MovieManager
 
 
-@pytest.mark.asyncio
-async def test_start():
-    # Create a mock for the set_default_backdrop method
-    set_default_backdrop_mock = AsyncMock()
+def test_start():
+    async def run_test():
+        set_default_backdrop_mock = AsyncMock()
+        with patch.object(MovieManager, 'set_default_backdrop', set_default_backdrop_mock):
+            movie_manager = MovieManager(db_config=None)
+            await movie_manager.start()
+            set_default_backdrop_mock.assert_called_once()
 
-    # Patch the set_default_backdrop method in the MovieManager class
-    with patch.object(MovieManager, 'set_default_backdrop', set_default_backdrop_mock):
-        movie_manager = MovieManager(db_config=None)  # Replace None with actual db_config if needed
-        await movie_manager.start()
-
-        # Assert that set_default_backdrop was called once
-        set_default_backdrop_mock.assert_called_once()
-
-        # Bonus: If you want to check the logging, you would need to patch 'logging.info' and check calls
+    asyncio.run(run_test())
 
 
-@pytest.mark.asyncio
-async def test_add_user():
-    # Mock for movie_queue_manager's add_user method
-    add_user_mock = AsyncMock()
+def test_add_user():
+    async def run_test():
+        add_user_mock = AsyncMock()
+        movie_manager = MovieManager(db_config=None)
+        movie_manager.movie_queue_manager = AsyncMock(add_user=add_user_mock)
+        await movie_manager.add_user('test_user', {'genre': 'comedy'})
+        add_user_mock.assert_called_once_with('test_user', {'genre': 'comedy'})
 
-    # Instance of MovieManager with a mocked movie_queue_manager
-    movie_manager = MovieManager(db_config=None)  # Replace None with actual db_config if needed
-    movie_manager.movie_queue_manager = AsyncMock(add_user=add_user_mock)
-
-    user_id = "test_user"
-    criteria = {"genre": "comedy"}
-
-    # Call the add_user method
-    await movie_manager.add_user(user_id, criteria)
-
-    # Assert that movie_queue_manager's add_user was called once with correct arguments
-    add_user_mock.assert_called_once_with(user_id, criteria)
-
-    # Bonus: To test logging, you would need to patch 'logging.info' and check its calls
+    asyncio.run(run_test())
 
 
-@pytest.mark.asyncio
-async def test_home():
-    # Mocks for dependencies
-    is_task_running_mock = AsyncMock(return_value=False)
-    populate_mock = AsyncMock()
-    render_template_mock = AsyncMock(return_value='rendered_template')
+def test_home():
+    async def run_test():
+        is_task_running_mock = lambda: False
+        populate_mock = AsyncMock()
+        render_template_mock = AsyncMock(return_value='rendered_template')
+        movie_manager = MovieManager(db_config=None)
+        movie_manager.movie_queue_manager = AsyncMock(
+            is_task_running=is_task_running_mock,
+            populate=populate_mock
+        )
+        orig_create_task = asyncio.create_task
+        with patch('movie_service.asyncio.create_task', lambda coro: orig_create_task(coro)):
+            with patch('movie_service.render_template', render_template_mock):
+                result = await movie_manager.home('test_user')
+                await asyncio.sleep(0)  # allow populate task to run
+                populate_mock.assert_called_once_with('test_user')
+                render_template_mock.assert_called_once_with(
+                    'home.html', default_backdrop_url=movie_manager.default_backdrop_url
+                )
+                assert result == 'rendered_template'
 
-    # Instance of MovieManager with mocked dependencies
-    movie_manager = MovieManager(db_config=None)  # Replace None with actual db_config if needed
-    movie_manager.movie_queue_manager = AsyncMock(
-        is_task_running=is_task_running_mock,
-        populate=populate_mock
-    )
+    asyncio.run(run_test())
 
-    with patch('movie_service.render_template', render_template_mock):
-        user_id = "test_user"
-        result = await movie_manager.home(user_id)
 
-        # Asserts
-        is_task_running_mock.assert_called_once()
-        populate_mock.assert_called_once_with(user_id)
-        render_template_mock.assert_called_once_with('home.html',
-                                                     default_backdrop_url=movie_manager.default_backdrop_url)
-        assert result == 'rendered_template'
+def test_set_default_backdrop():
+    async def run_test():
+        class Helper:
+            async def get_images_by_tmdb_id(self, tmdb_id):
+                return {'backdrops': ['backdrop_url']}
 
-    @pytest.mark.asyncio
-    async def test_set_default_backdrop():
-        # Mock for tmdb_helper's get_images_by_tmdb_id method
-        get_images_by_tmdb_id_mock = AsyncMock(return_value={'backdrops': ['backdrop_url']})
+            def get_full_image_url(self, path):
+                return f'full:{path}'
 
-        # Instance of MovieManager with a mocked tmdb_helper
-        movie_manager = MovieManager(db_config=None)  # Replace None with actual db_config if needed
-        movie_manager.tmdb_helper = AsyncMock(get_images_by_tmdb_id=get_images_by_tmdb_id_mock)
-
+        movie_manager = MovieManager(db_config=None)
+        movie_manager.tmdb_helper = Helper()
         await movie_manager.set_default_backdrop()
+        assert movie_manager.default_backdrop_url == 'full:backdrop_url'
 
-        # Assert that default_backdrop_url is set correctly
-        get_images_by_tmdb_id_mock.assert_called_once_with(movie_manager.default_movie_tmdb_id)
-        assert movie_manager.default_backdrop_url == movie_manager.tmdb_helper.get_full_image_url('backdrop_url')
-
+    asyncio.run(run_test())

--- a/tests/test_tmdb_client.py
+++ b/tests/test_tmdb_client.py
@@ -1,0 +1,31 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from scripts.tmdb_client import TMDbHelper
+
+
+def test_get_full_image_url():
+    helper = TMDbHelper('key')
+    url = helper.get_full_image_url('/path', size='w500')
+    assert url == 'https://image.tmdb.org/t/p/w500/path'
+
+
+def test_get_backdrop_image_for_home():
+    async def run_test():
+        helper = TMDbHelper('key')
+        with patch.object(helper, '_get', AsyncMock(return_value={'backdrops': [{'file_path': '/b.jpg'}]})):
+            url = await helper.get_backdrop_image_for_home(123)
+            assert url.endswith('/b.jpg')
+
+    asyncio.run(run_test())
+
+
+def test_get_backdrop_for_movie():
+    async def run_test():
+        helper = TMDbHelper('key')
+        helper.get_all_backdrop_images = AsyncMock(return_value=['url1', 'url2'])
+        with patch('random.choice', lambda x: x[0]):
+            url = await helper.get_backdrop_for_movie(123)
+            assert url == 'url1'
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- simplify async handling in existing tests
- add tests for movie queue utilities
- add tests for TMDb helper functions
- add tests for filter_backend utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bafa1e0a0832daea6410b58083dad