### PR TITLE
Refactor movie queue and fetcher

### DIFF
--- a/scripts/interfaces.py
+++ b/scripts/interfaces.py
@@ -4,5 +4,5 @@ from typing import Protocol, List, Dict, Any
 class MovieFetcher(Protocol):
     """Abstraction for objects that can fetch movies based on criteria."""
 
-    async def fetch_random_movies15(self, criteria: Dict[str, Any]) -> List[Dict[str, Any]]:
+    async def fetch_random_movies(self, criteria: Dict[str, Any], limit: int) -> List[Dict[str, Any]]:
         ...

--- a/scripts/movie.py
+++ b/scripts/movie.py
@@ -5,9 +5,9 @@ import time
 
 import httpx
 
-from settings import Config
+from settings import Config, DatabaseConnectionPool
 from db_utils import DatabaseQueryExecutor
-from scripts.filter_backend import ImdbRandomMovieFetcher, database_pool
+from scripts.filter_backend import ImdbRandomMovieFetcher
 from scripts.tmdb_client import TMDbHelper
 
 # Configure logging for better debugging
@@ -96,7 +96,8 @@ class Movie:
         self.tconst = tconst
         self.db_config = db_config
         self.movie_data = {}
-        self.query_executor = DatabaseQueryExecutor(database_pool)
+        self.pool = DatabaseConnectionPool(self.db_config)
+        self.query_executor = DatabaseQueryExecutor(self.pool)
         self.tmdb_helper = TMDbHelper(TMDB_API_KEY)  # Initialize TMDbHelper
         self.slug = None  # Assuming slug is available at initialization
         self.client = httpx.AsyncClient()  # Initialize once and reuse

--- a/tests/test_filter_backend.py
+++ b/tests/test_filter_backend.py
@@ -9,8 +9,8 @@ class TestMovieFilteringWithRealDatabase(unittest.TestCase):
         self.dbconfig = Config.STACKHERO_DB_CONFIG
         self.fetcher = ImdbRandomMovieFetcher(self.dbconfig)
 
-    async def test_fetch_random_movies25_meets_criteria(self):
-        """Test that fetch_random_movies25 fetches movies that meet the criteria."""
+    async def test_fetch_random_movies_meets_criteria(self):
+        """Test that fetch_random_movies fetches movies that meet the criteria."""
         criteria = {
             'min_year': 1990,
             'max_year': 2010,
@@ -21,10 +21,10 @@ class TestMovieFilteringWithRealDatabase(unittest.TestCase):
             'language': 'en',
             'genres': ['Action', 'Drama']
         }
-        movies = await self.fetcher.fetch_random_movies15(criteria)
+        movies = await self.fetcher.fetch_random_movies(criteria, 15)
 
-        # Ensure that 25 movies are returned
-        self.assertEqual(len(movies), 15, "Did not fetch exactly 25 movies")
+        # Ensure that the correct number of movies are returned
+        self.assertEqual(len(movies), 15, "Did not fetch exactly 15 movies")
 
         # Assert that returned movies match the criteria
         for movie in movies:

--- a/tests/test_movie_queue.py
+++ b/tests/test_movie_queue.py
@@ -5,15 +5,13 @@ from scripts.movie_queue import MovieQueue
 
 
 class DummyFetcher:
-    async def fetch_random_movies15(self, criteria):
+    async def fetch_random_movies(self, criteria, limit):
         return []
 
 
 def test_get_user_queue_and_stop_flag():
     async def run_test():
-        MovieQueue._instance = None
-        queue = asyncio.Queue()
-        mq = MovieQueue(db_config=None, queue=queue, movie_fetcher=DummyFetcher())
+        mq = MovieQueue(db_config=None, queue_max_size=20, movie_fetcher=DummyFetcher())
         user_queue = await mq.get_user_queue('u1')
         assert 'u1' in mq.user_queues
         assert isinstance(user_queue, asyncio.Queue)
@@ -25,8 +23,7 @@ def test_get_user_queue_and_stop_flag():
 
 def test_is_task_running():
     async def run_test():
-        MovieQueue._instance = None
-        mq = MovieQueue(db_config=None, queue=asyncio.Queue(), movie_fetcher=DummyFetcher())
+        mq = MovieQueue(db_config=None, queue_max_size=20, movie_fetcher=DummyFetcher())
         assert mq.is_task_running('u1') is False
         task = asyncio.create_task(asyncio.sleep(0))
         mq.user_queues['u1'] = {'populate_task': task}
@@ -39,8 +36,7 @@ def test_is_task_running():
 
 def test_enqueue_movie_deduplication():
     async def run_test():
-        MovieQueue._instance = None
-        mq = MovieQueue(db_config=None, queue=asyncio.Queue(), movie_fetcher=DummyFetcher())
+        mq = MovieQueue(db_config=None, queue_max_size=20, movie_fetcher=DummyFetcher())
 
         class DummyMovie:
             def __init__(self, tconst, db_config):


### PR DESCRIPTION
## Summary
- decouple movie fetching from global DB pool
- rename fetcher method and allow variable limits
- remove MovieQueue singleton and make queue size configurable
- adapt MovieManager to new MovieQueue API
- update tests for new interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc3841540832dad6ed749c60ea6cc