### PR TITLE
Refactor queue fetching

### DIFF
--- a/scripts/interfaces.py
+++ b/scripts/interfaces.py
@@ -4,5 +4,8 @@ from typing import Protocol, List, Dict, Any
 class MovieFetcher(Protocol):
     """Abstraction for objects that can fetch movies based on criteria."""
 
-    async def fetch_random_movies15(self, criteria: Dict[str, Any]) -> List[Dict[str, Any]]:
+    async def fetch_random_movies(
+        self, criteria: Dict[str, Any], limit: int
+    ) -> List[Dict[str, Any]]:
+        """Fetch a number of random movies matching the given criteria."""
         ...

--- a/tests/test_filter_backend.py
+++ b/tests/test_filter_backend.py
@@ -1,13 +1,13 @@
 import asyncio
 import unittest
-from settings import Config
+from settings import Config, DatabaseConnectionPool
 from scripts.filter_backend import ImdbRandomMovieFetcher
 
 @unittest.skip("requires database access")
 class TestMovieFilteringWithRealDatabase(unittest.TestCase):
     def setUp(self):
         self.dbconfig = Config.STACKHERO_DB_CONFIG
-        self.fetcher = ImdbRandomMovieFetcher(self.dbconfig)
+        self.fetcher = ImdbRandomMovieFetcher(DatabaseConnectionPool(self.dbconfig))
 
     async def test_fetch_random_movies25_meets_criteria(self):
         """Test that fetch_random_movies25 fetches movies that meet the criteria."""
@@ -21,7 +21,7 @@ class TestMovieFilteringWithRealDatabase(unittest.TestCase):
             'language': 'en',
             'genres': ['Action', 'Drama']
         }
-        movies = await self.fetcher.fetch_random_movies15(criteria)
+        movies = await self.fetcher.fetch_random_movies(criteria, 15)
 
         # Ensure that 25 movies are returned
         self.assertEqual(len(movies), 15, "Did not fetch exactly 25 movies")

--- a/tests/test_movie_queue.py
+++ b/tests/test_movie_queue.py
@@ -5,15 +5,13 @@ from scripts.movie_queue import MovieQueue
 
 
 class DummyFetcher:
-    async def fetch_random_movies15(self, criteria):
+    async def fetch_random_movies(self, criteria, limit):
         return []
 
 
 def test_get_user_queue_and_stop_flag():
     async def run_test():
-        MovieQueue._instance = None
-        queue = asyncio.Queue()
-        mq = MovieQueue(db_config=None, queue=queue, movie_fetcher=DummyFetcher())
+        mq = MovieQueue(db_pool=None, movie_fetcher=DummyFetcher(), queue_size=15)
         user_queue = await mq.get_user_queue('u1')
         assert 'u1' in mq.user_queues
         assert isinstance(user_queue, asyncio.Queue)
@@ -25,8 +23,7 @@ def test_get_user_queue_and_stop_flag():
 
 def test_is_task_running():
     async def run_test():
-        MovieQueue._instance = None
-        mq = MovieQueue(db_config=None, queue=asyncio.Queue(), movie_fetcher=DummyFetcher())
+        mq = MovieQueue(db_pool=None, movie_fetcher=DummyFetcher(), queue_size=15)
         assert mq.is_task_running('u1') is False
         task = asyncio.create_task(asyncio.sleep(0))
         mq.user_queues['u1'] = {'populate_task': task}
@@ -39,11 +36,10 @@ def test_is_task_running():
 
 def test_enqueue_movie_deduplication():
     async def run_test():
-        MovieQueue._instance = None
-        mq = MovieQueue(db_config=None, queue=asyncio.Queue(), movie_fetcher=DummyFetcher())
+        mq = MovieQueue(db_pool=None, movie_fetcher=DummyFetcher(), queue_size=15)
 
         class DummyMovie:
-            def __init__(self, tconst, db_config):
+            def __init__(self, tconst, db_pool):
                 self.tconst = tconst
 
             async def get_movie_data(self):

--- a/tests/test_movie_service.py
+++ b/tests/test_movie_service.py
@@ -9,6 +9,7 @@ def test_start():
         set_default_backdrop_mock = AsyncMock()
         with patch.object(MovieManager, 'set_default_backdrop', set_default_backdrop_mock):
             movie_manager = MovieManager(db_config=None)
+            movie_manager.db_pool.init_pool = AsyncMock()
             await movie_manager.start()
             set_default_backdrop_mock.assert_called_once()
 


### PR DESCRIPTION
## Summary
- simplify `MovieFetcher` interface
- refactor `filter_backend` to accept connection pools and configurable limits
- remove singleton/event logic from `MovieQueue`
- inject DB pool into `MovieManager` and `Movie` classes
- update tests for new APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc3841540832dad6ed749c60ea6cc