### PR TITLE
Improve logging clarity

### DIFF
--- a/add_movie_slugs.py
+++ b/add_movie_slugs.py
@@ -9,8 +9,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 # Database configurations from environment variables
 DB_CONFIG = {
@@ -45,7 +44,7 @@ async def add_slug_column(pool):
                     ALTER TABLE `title.basics`
                     ADD COLUMN `slug` VARCHAR(255) AFTER `primaryTitle`;
                 """)
-                logging.info("Slug column added to 'title.basics' table.")
+                logger.info("Slug column added to 'title.basics' table.")
 
 async def populate_slugs(pool):
     async with pool.acquire() as conn:
@@ -66,7 +65,7 @@ async def populate_slugs(pool):
                     SET `slug` = %s
                     WHERE `tconst` = %s;
                 """, (f'film/{slug}', movie['tconst']))
-                logging.info(f"Slug '{slug}' added to movie with tconst: {movie['tconst']}")
+                logger.info(f"Slug '{slug}' added to movie with tconst: {movie['tconst']}")
 
 async def main():
     pool = await aiomysql.create_pool(**DB_CONFIG)
@@ -74,7 +73,7 @@ async def main():
         await add_slug_column(pool)
         await populate_slugs(pool)
     except Exception as e:
-        logging.error(f"An error occurred: {e}")
+        logger.error(f"An error occurred: {e}")
     finally:
         pool.close()
         await pool.wait_closed()

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import logging
 import sys
 import time
 import uuid
-
 from redis import asyncio as aioredis
 from quart import Quart, request, redirect, url_for, session, render_template, g
 from quart_session import Session
@@ -16,17 +15,13 @@ from movie_service import MovieManager
 import os
 from local_env_setup import setup_local_environment
 
-setup_logging(log_level=logging.DEBUG)
+setup_logging(log_level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 # Automatically set up local environment if not in production
 if os.getenv("FLASK_ENV") != "production":
     setup_local_environment()
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(filename)s - %(funcName)s - %(levelname)s - %(message)s'
-)
 
 
 def create_app():
@@ -68,28 +63,43 @@ def create_app():
             if 'user_id' not in session:
                 # Generate a new UUID if not present and add it to the session
                 session['user_id'] = str(uuid.uuid4())
-                logging.info(f"New user_id generated: {session['user_id']}. Correlation ID: {g.correlation_id}")
+                logger.debug(
+                    "New user_id generated: %s. Correlation ID: %s",
+                    session["user_id"],
+                    g.correlation_id,
+                )
 
                 # Define default criteria or fetch it from somewhere if you have personalized criteria logic
                 default_criteria = {"min_year": 1900, "max_year": 2023, "min_rating": 7.0,
                                     "genres": ["Action", "Comedy"]}
 
                 # Add user with criteria
-                await movie_manager.add_user(session['user_id'], default_criteria)
+                if asyncio.iscoroutinefunction(movie_manager.add_user):
+                    await movie_manager.add_user(session['user_id'], default_criteria)
+                else:
+                    movie_manager.add_user(session['user_id'], default_criteria)
 
                 # Assuming movie_manager provides access to the MovieQueue instance,
                 # start preloading movies into the user's queue
                 # This line is the main addition to integrate start_populate_task
-                await movie_manager.movie_queue_manager.start_populate_task(session['user_id'])
+                start_task = movie_manager.movie_queue_manager.start_populate_task
+                if asyncio.iscoroutinefunction(start_task):
+                    await start_task(session['user_id'])
+                else:
+                    start_task(session['user_id'])
 
             else:
-                logging.info(f"Existing user_id found: {session['user_id']}")
+                logger.debug("Existing user_id found: %s", session["user_id"])
 
             # Calculate and log request size
             req_size = sys.getsizeof(await request.get_data())
-            logging.info(f"Request Size: {req_size} bytes. Correlation ID: {g.correlation_id}")
+            logger.debug(
+                "Request Size: %s bytes. Correlation ID: %s",
+                req_size,
+                g.correlation_id,
+            )
         except Exception as e:
-            logging.error(f"Error in session management: {e}")
+            logger.error("Error in session management: %s", e)
 
     # Set up Redis for session management using aioredis
 
@@ -103,7 +113,12 @@ def create_app():
         user_id = session.get('user_id')
 
         # Pass the user_id along with the tconst to the render_movie_by_tconst method
-        logging.info(f"Fetching movie details for tconst: {tconst}, user_id: {user_id}. Correlation ID: {g.correlation_id}")
+        logger.info(
+            "Fetching movie details for tconst: %s, user_id: %s. Correlation ID: %s",
+            tconst,
+            user_id,
+            g.correlation_id,
+        )
         return await movie_manager.render_movie_by_tconst(user_id, tconst, template_name='movie.html')
 
     @app.route('/')
@@ -114,7 +129,12 @@ def create_app():
     @app.route('/movie/<slug>')
     async def movie_details(slug):
         user_id = session.get('user_id')
-        logging.info(f"Fetching movie details for slug: {slug}, user_id: {user_id}. Correlation ID: {g.correlation_id}")
+        logger.info(
+            "Fetching movie details for slug: %s, user_id: %s. Correlation ID: %s",
+            slug,
+            user_id,
+            g.correlation_id,
+        )
         # Fetch movie details by slug
         movie_details = await movie_manager.get_movie_by_slug(user_id, slug)
 
@@ -128,7 +148,11 @@ def create_app():
     @app.route('/next_movie', methods=['GET', 'POST'])
     async def next_movie():
         user_id = session.get('user_id')
-        logging.info(f"Requesting next movie for user_id: {user_id}. Correlation ID: {g.correlation_id}")
+        logger.info(
+            "Requesting next movie for user_id: %s. Correlation ID: %s",
+            user_id,
+            g.correlation_id,
+        )
 
         if 'failed_attempts' not in session:
             session['failed_attempts'] = 0
@@ -144,19 +168,18 @@ def create_app():
                 return response
             else:
                 session['failed_attempts'] += 1
-                logging.info(
-                    f"No movies available, waiting for {wait_seconds} seconds before retrying...")
+                logger.debug("No movies available, waiting for %s seconds before retrying...", wait_seconds)
                 await asyncio.sleep(wait_seconds)  # Wait before retrying
 
             # Check if we should trigger a movie queue population
             if session['failed_attempts'] >= 4:
-                logging.info(f"Failed attempts threshold reached. Triggering movie queue population. Correlation ID: {g.correlation_id}")
+                logger.info("Failed attempts threshold reached. Triggering movie queue population. Correlation ID: %s", g.correlation_id)
                 await movie_manager.movie_queue_manager.start_populate_task(session['user_id'])
 
                 session['failed_attempts'] = 0  # Optionally reset failed attempts
 
         # After 30 seconds, if no movie is found, log a message and return a custom response
-        logging.warning(f"No more movies available after trying for 30 seconds. Correlation ID: {g.correlation_id}")
+        logger.warning("No more movies available after trying for 30 seconds. Correlation ID: %s", g.correlation_id)
         return 'No more movies available. Please try again later.', 200
 
     @app.route('/previous_movie', methods=['GET', 'POST'])
@@ -164,9 +187,9 @@ def create_app():
     # @memory_profile  # Apply memory profiling
     async def previous_movie():
         user_id = session.get('user_id')
-        logging.info(f"Requesting previous movie for user_id: {user_id}. Correlation ID: {g.correlation_id}")
         response = await movie_manager.previous_movie(user_id)
-        return response if response else ('No previous movies', 200)
+        logger.info("Requesting previous movie for user_id: %s. Correlation ID: %s", user_id, g.correlation_id)
+        return response if response else ("No previous movies", 200)
 
     @app.route('/setFilters')
     async def set_filters():
@@ -174,8 +197,7 @@ def create_app():
         current_filters = session.get('current_filters', {})  # Retrieve current filters from session
 
         start_time = time.time()  # Capture start time for operation
-        logging.info(f"Starting to set filters for user_id: {user_id} with current filters: {current_filters}. Correlation ID: {g.correlation_id}")
-
+        logger.info("Starting to set filters for user_id: %s with current filters: %s. Correlation ID: %s", user_id, current_filters, g.correlation_id)
 
         try:
             # Pass current_filters to the template
@@ -183,12 +205,12 @@ def create_app():
 
             # Log the successful completion and time taken
             elapsed_time = time.time() - start_time
-            logging.info(f"Completed setting filters for user_id: {user_id} in {elapsed_time:.2f} seconds. Correlation ID: {g.correlation_id}")
+            logger.info("Completed setting filters for user_id: %s in %.2f seconds. Correlation ID: %s", user_id, elapsed_time, g.correlation_id)
 
             return response
         except Exception as e:
             # Exception logging with detailed context
-            logging.error(f"Error setting filters for user_id: {user_id}, Error: {e}")
+            logger.error("Error setting filters for user_id: %s, Error: %s", user_id, e)
             raise  # Re-raise the exception or handle it as per your error handling policy
 
     @app.route('/filtered_movie', methods=['POST'])
@@ -202,8 +224,7 @@ def create_app():
         session['current_filters'] = form_data.to_dict()
 
         start_time = time.time()  # Capture start time for operation
-        logging.info(f"Starting filtering movies for user_id: {user_id} with form data: {form_data}. Correlation ID: {g.correlation_id}")
-
+        logger.info("Starting filtering movies for user_id: %s with form data: %s. Correlation ID: %s", user_id, form_data, g.correlation_id)
 
         try:
             # Here, you can log before each significant operation to see its duration
@@ -211,22 +232,22 @@ def create_app():
             # Simulate processing and filtering
             await asyncio.sleep(5)  # Simulate some async operation
             filter_elapsed_time = time.time() - filter_start_time
-            logging.info(f"Simulated filtering operation took {filter_elapsed_time:.2f} seconds")
+            logger.debug("Simulated filtering operation took %.2f seconds", filter_elapsed_time)
 
             # Before calling the movie_manager's filtered_movie method, log the start time
             movie_filter_start_time = time.time()
             response = await movie_manager.filtered_movie(user_id, form_data)
             movie_filter_elapsed_time = time.time() - movie_filter_start_time
-            logging.info(f"movie_manager.filtered_movie operation took {movie_filter_elapsed_time:.2f} seconds. Correlation ID: {g.correlation_id}")
+            logger.debug("movie_manager.filtered_movie operation took %.2f seconds. Correlation ID: %s", movie_filter_elapsed_time, g.correlation_id)
 
             # Log the successful completion and time taken
             elapsed_time = time.time() - start_time
-            logging.info(f"Completed filtering movies for user_id: {user_id} in {elapsed_time:.2f} seconds. Correlation ID: {g.correlation_id}")
+            logger.info("Completed filtering movies for user_id: %s in %.2f seconds. Correlation ID: %s", user_id, elapsed_time, g.correlation_id)
 
             return response
         except Exception as e:
             # Exception logging with detailed context
-            logging.error(f"Error filtering movies for user_id: {user_id}, Error: {e}")
+            logger.error("Error filtering movies for user_id: %s, Error: %s", user_id, e)
             raise  # Re-raise the exception or handle it as per your error handling policy
 
     def get_user_criteria():
@@ -243,8 +264,12 @@ def create_app():
         criteria = get_user_criteria()  # Get criteria for the user
 
         # Initialize user's movie queue with criteria in MovieManager
-        await movie_manager.movie_queue_manager.add_user(user_id, criteria)
-        logging.info(f"New user handled with user_id: {user_id}. Correlation ID: {g.correlation_id}")
+        add_user_fn = movie_manager.movie_queue_manager.add_user
+        if asyncio.iscoroutinefunction(add_user_fn):
+            await add_user_fn(user_id, criteria)
+        else:
+            add_user_fn(user_id, criteria)
+        logger.info("New user handled with user_id: %s. Correlation ID: %s", user_id, g.correlation_id)
 
         # Redirect to the home page or another appropriate page
         return redirect(url_for('home'))

--- a/db_utils.py
+++ b/db_utils.py
@@ -67,8 +67,7 @@ import asyncio
 import logging
 import time
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 
 # Assume SQL query definitions remain the same
@@ -83,7 +82,7 @@ class DatabaseQueryExecutor:
         start_time = time.time()  # Start timing before acquiring connection
         conn = await self.db_pool.get_async_connection()
         if not conn:
-            logging.error("Failed to acquire a database connection.")
+            logger.error("Failed to acquire a database connection.")
             return None
 
         try:
@@ -100,18 +99,18 @@ class DatabaseQueryExecutor:
                     raise ValueError(f"Invalid fetch parameter: {fetch}")
                 return result
         except Exception as e:
-            logging.error(f"An error occurred while executing the query: {e}")
+            logger.error(f"An error occurred while executing the query: {e}")
             return None
         finally:
             await self.db_pool.release_async_connection(conn)
             end_time = time.time()  # End timing after releasing connection
-            logging.info(f"Query and connection handling executed in {end_time - start_time:.2f} seconds.")
+            logger.info(f"Query and connection handling executed in {end_time - start_time:.2f} seconds.")
 
 
 async def init_pool():
     db_pool = DatabaseConnectionPool(Config.get_db_config())
     await db_pool.init_pool()
-    logging.info("Database connection pool initialized.")
+    logger.info("Database connection pool initialized.")
     return db_pool
 
 

--- a/logging_config.py
+++ b/logging_config.py
@@ -27,4 +27,7 @@ def setup_logging(log_level=logging.INFO):
     )
 
     # Log the initialization of logging
-    logging.info("Logging initialized with level: %s", logging.getLevelName(log_level))
+    logging.getLogger(__name__).info(
+        "Logging initialized with level: %s", logging.getLevelName(log_level)
+    )
+

--- a/middleware.py
+++ b/middleware.py
@@ -2,10 +2,16 @@ import logging
 from uuid import uuid4
 from quart import request, g
 
+logger = logging.getLogger(__name__)
+
 async def add_correlation_id():
     """
     Middleware to add a correlation ID to every request.
     """
     correlation_id = request.headers.get("X-Correlation-ID", str(uuid4()))
     g.correlation_id = correlation_id
-    logging.info("New request received. Correlation ID: %s, Path: %s", correlation_id, request.path)
+    logger.debug(
+        "New request received. Correlation ID: %s, Path: %s",
+        correlation_id,
+        request.path,
+    )

--- a/scripts/movie.py
+++ b/scripts/movie.py
@@ -10,12 +10,8 @@ from db_utils import DatabaseQueryExecutor
 from scripts.filter_backend import ImdbRandomMovieFetcher
 from scripts.tmdb_client import TMDbHelper
 
-# Configure logging for better debugging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(filename)s - %(funcName)s - %(levelname)s - %(message)s",
-)
-# Set httpx logging level to ERROR to reduce verbosity
+# Configure module logger
+logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.ERROR)
 
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -112,12 +108,12 @@ class Movie:
         )
         if result:
             self.slug = result["slug"]  # Assuming the column name in the DB is 'slug'
-            logging.info(f"Slug for tconst {self.tconst}: {self.slug}")
+            logger.info(f"Slug for tconst {self.tconst}: {self.slug}")
         else:
-            logging.warning(f"No slug found for tconst: {self.tconst}")
+            logger.warning(f"No slug found for tconst: {self.tconst}")
 
         method_time = time.time() - start_time
-        logging.info(
+        logger.info(
             f"Completed fetch_movie_slug for {self.tconst} in {method_time:.2f} seconds."
         )
 
@@ -146,19 +142,19 @@ class Movie:
                     ),
                 }
 
-                logging.info(f"Ratings data: {ratings_data}")  # Log the ratings data
+                logger.info(f"Ratings data: {ratings_data}")  # Log the ratings data
 
                 query_time = time.time() - start_time  # Measure query execution time
-                logging.info(f"Fetched movie ratings in {query_time:.2f} seconds")
+                logger.info(f"Fetched movie ratings in {query_time:.2f} seconds")
 
                 return ratings_data
 
             except KeyError as e:
-                logging.error(f"Error in fetch_movie_ratings: {e}")
-                logging.error(f"Result missing expected key: {result}")
+                logger.error(f"Error in fetch_movie_ratings: {e}")
+                logger.error(f"Result missing expected key: {result}")
                 return None
         else:
-            logging.info(f"No ratings found for tconst: {tconst}")
+            logger.info(f"No ratings found for tconst: {tconst}")
             return None
 
     async def get_movie_data(self):
@@ -168,7 +164,7 @@ class Movie:
         await self.fetch_movie_slug()
 
         if not tmdb_id:
-            logging.warning(f"No TMDB ID found for tconst: {self.tconst}")
+            logger.warning(f"No TMDB ID found for tconst: {self.tconst}")
             return None
 
         # Execute coroutines concurrently
@@ -257,7 +253,7 @@ class Movie:
         }
 
         method_time = time.time() - start_time
-        logging.info(
+        logger.info(
             f"Completed get_movie_data for {self.tconst} in {method_time:.2f} seconds."
         )
 

--- a/scripts/movie_queue.py
+++ b/scripts/movie_queue.py
@@ -12,15 +12,11 @@ from scripts.filter_backend import ImdbRandomMovieFetcher
 from .interfaces import MovieFetcher
 from settings import DatabaseConnectionPool
 
-# Configure logging for better clarity
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(filename)s - %(funcName)s - %(levelname)s - %(message)s",
-)
+logger = logging.getLogger(__name__)
 # Set the working directory to the parent directory for relative path resolutions
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(parent_dir)
-logging.debug(f"Current working directory after change: {os.getcwd()}")
+logger.debug(f"Current working directory after change: {os.getcwd()}")
 
 
 class MovieQueue:
@@ -54,7 +50,7 @@ class MovieQueue:
                 }
             return self.user_queues[user_id]["queue"]
         except Exception as e:
-            logging.error(
+            logger.error(
                 f"Unexpected error in get_user_queue for user_id: {user_id}: {e}",
                 exc_info=True,
             )
@@ -71,13 +67,13 @@ class MovieQueue:
                 self.user_queues[user_id]["populate_task"] = asyncio.create_task(
                     self.populate(user_id)
                 )
-                logging.info(
+                logger.info(
                     f"Added and started population task for new user: {user_id}"
                 )
         except Exception as e:
             tb_str = traceback.format_exception(e)
-            logging.error("".join(tb_str))
-            logging.error(
+            logger.error("".join(tb_str))
+            logger.error(
                 f"Failed to add new user or start population task for user_id: {user_id}. Exception: {e}"
             )
 
@@ -88,13 +84,13 @@ class MovieQueue:
 
             async with self.lock:
                 self.user_queues[user_id]["criteria"] = new_criteria
-                logging.info(
+                logger.info(
                     f"Criteria for user_id {user_id} updated to: {new_criteria}"
                 )
         except Exception as e:
             tb_str = traceback.format_exception(e)
-            logging.error("".join(tb_str))
-            logging.error(
+            logger.error("".join(tb_str))
+            logger.error(
                 f"Failed to set new criteria for user_id: {user_id}. Exception: {e}"
             )
 
@@ -108,13 +104,13 @@ class MovieQueue:
                 user_queue_info["populate_task"] = asyncio.create_task(
                     self.populate(user_id)
                 )
-                logging.info(f"Populate task started for user_id: {user_id}")
+                logger.info(f"Populate task started for user_id: {user_id}")
             else:
-                logging.info(
+                logger.info(
                     f"Populate task for user_id: {user_id} is already running or not ready to be restarted."
                 )
         except Exception as e:
-            logging.error(
+            logger.error(
                 f"Failed to start populate task for user_id: {user_id}. Exception: {e}",
                 exc_info=True,
             )
@@ -131,9 +127,9 @@ class MovieQueue:
                     "populate_task"
                 ]  # Wait for the task to be cancelled
             except asyncio.CancelledError:
-                logging.info(f"Populate task for user_id {user_id} cancelled.")
+                logger.info(f"Populate task for user_id {user_id} cancelled.")
             finally:
-                logging.info(f"Finalizing stop for user_id {user_id}.")
+                logger.info(f"Finalizing stop for user_id {user_id}.")
 
     async def empty_queue(self, user_id):
         try:
@@ -143,11 +139,11 @@ class MovieQueue:
                 async with self.lock:
                     while not queue.empty():
                         await queue.get()
-                    logging.info(f"Movie queue for user_id {user_id} emptied")
+                    logger.info(f"Movie queue for user_id {user_id} emptied")
         except Exception as e:
             tb_str = traceback.format_exception(e)
-            logging.error("".join(tb_str))
-            logging.error(f"Error emptying queue for user_id: {user_id}: {e}")
+            logger.error("".join(tb_str))
+            logger.error(f"Error emptying queue for user_id: {user_id}: {e}")
 
     async def mark_movie_seen(self, user_id, tconst):
         info = self.user_queues.get(user_id)
@@ -176,12 +172,12 @@ class MovieQueue:
 
                     if current_queue_size <= 1:
                         if await self.check_stop_flag(user_id):
-                            logging.info(
+                            logger.info(
                                 f"Abort loading more movies for user_id: {user_id} due to stop signal."
                             )
                             break
 
-                        logging.info(
+                        logger.info(
                             f"Queue size below threshold for user_id: {user_id}, loading more movies..."
                         )
                         await self.load_movies_into_queue(user_id)
@@ -193,18 +189,18 @@ class MovieQueue:
                         await asyncio.sleep(0.5)
 
                 except asyncio.CancelledError:
-                    logging.info(
+                    logger.info(
                         f"Populate task for user_id: {user_id} has been cancelled."
                     )
                     break
                 except Exception as e:
-                    logging.exception(
+                    logger.exception(
                         f"Exception in populate for user_id: {user_id}: {e}"
                     )
         finally:
             if completion_event:
                 completion_event.set()
-            logging.info(
+            logger.info(
                 f"Population task for user_id: {user_id} is checking for more work or completing."
             )
 
@@ -242,15 +238,15 @@ class MovieQueue:
                     ):
                         await user_queue.put(movie_data_tmdb)
                         self.movie_enqueue_count += 1
-                        logging.info(
+                        logger.info(
                             f"[{self.movie_enqueue_count}] Enqueued movie '{movie_data_tmdb.get('title')}' with tconst: {tconst} for user_id: {user_id} "
                             f"(fetch time: {fetch_time:.2f}s, total time: {time.time() - start_time:.2f}s)"
                         )
 
         except Exception as e:
             tb_str = traceback.format_exception(e)
-            logging.error("".join(tb_str))
-            logging.error(
+            logger.error("".join(tb_str))
+            logger.error(
                 f"Error fetching/enqueuing movie {tconst} for user_id: {user_id}: {e}"
             )
 
@@ -264,7 +260,7 @@ class MovieQueue:
                 and "criteria" in self.user_queues[user_id]
                 else {}
             )
-            logging.info(
+            logger.info(
                 f"Loading movies into queue for user_id: {user_id} with criteria: {user_criteria}"
             )
 
@@ -276,11 +272,11 @@ class MovieQueue:
                 fetch_time = time.time() - fetch_start_time
 
                 if rows:
-                    logging.debug(
+                    logger.debug(
                         f"Fetched {len(rows)} movies for user_id: {user_id} based on criteria: {user_criteria} (fetch time: {fetch_time:.2f}s)"
                     )
                 else:
-                    logging.warning(
+                    logger.warning(
                         f"No movies fetched for user_id: {user_id} with the given criteria: {user_criteria}"
                     )
 
@@ -295,14 +291,14 @@ class MovieQueue:
 
         except Exception as e:
             tb_str = traceback.format_exception(e)
-            logging.error("".join(tb_str))
-            logging.error(
+            logger.error("".join(tb_str))
+            logger.error(
                 f"Error loading movies into queue for user_id: {user_id}: {e}"
             )
 
         finally:  # Log total time in all cases
             total_time = time.time() - start_time
-            logging.info(
+            logger.info(
                 f"Completed loading movies into queue for user_id: {user_id} (total time: {total_time:.2f}s)"
             )
 
@@ -318,11 +314,11 @@ class MovieQueue:
                 user_queue_info["populate_task"] = asyncio.create_task(
                     self.populate(user_id)
                 )
-                logging.info(f"Populate task restarted for user_id: {user_id}")
+                logger.info(f"Populate task restarted for user_id: {user_id}")
         except Exception as e:
             tb_str = traceback.format_exception(e)
-            logging.error("".join(tb_str))
-            logging.error(
+            logger.error("".join(tb_str))
+            logger.error(
                 f"Failed to update criteria and reset for user_id: {user_id}. Exception: {e}"
             )
 
@@ -339,7 +335,7 @@ class MovieQueue:
 #
 #     # Set criteria and start population tasks for each user
 #     for user_id, criteria in user_criteria.items():
-#         logging.info(f"Setting criteria for {user_id}: {criteria}")
+#         logger.info(f"Setting criteria for {user_id}: {criteria}")
 #         await movie_queue_manager.set_criteria(user_id, criteria)
 #         movie_queue_manager.start_populate_task(user_id)
 #
@@ -350,9 +346,9 @@ class MovieQueue:
 #     for user_id in user_criteria.keys():
 #         await movie_queue_manager.stop_populate_task(user_id)
 #         await movie_queue_manager.empty_queue(user_id)
-#         logging.info(f"Queue for {user_id} stopped and emptied")
+#         logger.info(f"Queue for {user_id} stopped and emptied")
 #
-#     logging.info("All tasks completed")
+#     logger.info("All tasks completed")
 #
 # if __name__ == "__main__":
 #     asyncio.run(main())


### PR DESCRIPTION
## Summary
- use module-level loggers with `logging.getLogger`
- drop per-module `basicConfig` usage
- shift verbose logs to debug
- tweak session setup to handle non-async mocks in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bd3a661d8832db4301491d0d6938f