### PR TITLE
Fix backdrop overlay layout and quart config

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,12 @@ import uuid
 
 from redis import asyncio as aioredis
 from quart import Quart, request, redirect, url_for, session, render_template, g
+
+
+class FixedQuart(Quart):
+    """Quart subclass ensuring Flask compatibility keys."""
+    default_config = dict(Quart.default_config)
+    default_config.setdefault("PROVIDE_AUTOMATIC_OPTIONS", True)
 from quart_session import Session
 
 import settings
@@ -26,7 +32,7 @@ if os.getenv("FLASK_ENV") != "production":
 
 
 def create_app():
-    app = Quart(__name__)
+    app = FixedQuart(__name__)
     app.config.from_object(settings.Config)
 
 

--- a/templates/movie_card.html
+++ b/templates/movie_card.html
@@ -399,19 +399,10 @@
 
         /* New Pseudo-element for gradient overlay */
         .backdrop-container::before {
-            /*background-repeat: no-repeat;*/
             content: "";
-            display: block;
-
-            /*controls height of gradient*/
-
-            height: 530px;
-            left: 50%;
-            pointer-events: none;
             position: absolute;
-            top: 0;
-            transform: translateX(-50%);
-            width: 100%; /* Make sure it spans the full width */
+            inset: 0; /* Cover the entire container */
+            pointer-events: none;
             z-index: 1;
             /* Combined Background Gradients */
             background: /* First Linear Gradient (horizontal) */ linear-gradient(90deg,
@@ -819,7 +810,6 @@
 
 <body>
 <div class="backdrop-container"></div>
-<div class="background-fade-overlay"></div>
 
 
 <div class="movie-card-container">


### PR DESCRIPTION
## Summary
- tweak gradient overlay so it covers the backdrop container properly
- remove unused fade overlay element
- subclass Quart to add PROVIDE_AUTOMATIC_OPTIONS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d12054408832d8cb5cc4a3fb8ff11