### PR TITLE
feat: secure secret management

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Install the required Python packages: pip install -r requirements.txt.
 Quart is used as the async web framework. It pulls in Flask and Jinja2 automatically, so they do not need to be pinned separately.
 
 ## Configuration
-Edit settings.py to include your database credentials, API keys, and other necessary configurations.
+Sensitive configuration such as database credentials and API keys is loaded from
+environment variables. Populate the variables described in `settings.py` or use a
+secrets manager (e.g., HashiCorp Vault, AWS Secrets Manager) to supply them at
+runtime. Rotating these values in the environment or vault takes effect without
+code changes.
+
 The runtime.txt file should reflect the Python version compatible with your environment.
 
 ## Usage

--- a/local_env_setup.py
+++ b/local_env_setup.py
@@ -9,45 +9,31 @@ def setup_local_environment():
     # Load environment variables from .env file
     load_dotenv(dotenv_path=".env", override=True)
 
-    # Default environment setup
     os.environ.setdefault("FLASK_ENV", "development")
     os.environ.setdefault("SESSION_TYPE", "redis")
     os.environ.setdefault("REDIS_HOST", "localhost")
     os.environ.setdefault("REDIS_PORT", "6379")
-    os.environ.setdefault("REDIS_PASSWORD", "")
-    
+    os.environ.setdefault("REDIS_PASSWORD", os.getenv("REDIS_PASSWORD", ""))
+
     # Configure MySQL settings based on FLASK_ENV
     if os.getenv("FLASK_ENV") == "production":
-        # Production database settings
-        os.environ.setdefault("MYSQL_HOST", "prod-db-hostname")  # Replace with production DB host
-        os.environ.setdefault("MYSQL_USER", "prod_user")  # Replace with production DB username
-        os.environ.setdefault("MYSQL_PASSWORD", "prod_password")  # Replace with production DB password
-        os.environ.setdefault("MYSQL_DB", "prod_database")  # Replace with production database name
-        os.environ.setdefault("USER_DB_HOST", "prod-db-hostname")  # Replace with production user DB host
-        os.environ.setdefault("USER_DB_USER", "prod_user")  # Replace with production user DB username
-        os.environ.setdefault("USER_DB_PASSWORD", "prod_password")  # Replace with production user DB password
-        os.environ.setdefault("USER_DB_NAME", "prod_user_database")  # Replace with production user database name
+        os.environ.setdefault("MYSQL_HOST", os.getenv("MYSQL_HOST", ""))
+        os.environ.setdefault("MYSQL_USER", os.getenv("MYSQL_USER", ""))
+        os.environ.setdefault("MYSQL_PASSWORD", os.getenv("MYSQL_PASSWORD", ""))
+        os.environ.setdefault("MYSQL_DB", os.getenv("MYSQL_DB", ""))
+        os.environ.setdefault("USER_DB_HOST", os.getenv("USER_DB_HOST", ""))
+        os.environ.setdefault("USER_DB_USER", os.getenv("USER_DB_USER", ""))
+        os.environ.setdefault("USER_DB_PASSWORD", os.getenv("USER_DB_PASSWORD", ""))
+        os.environ.setdefault("USER_DB_NAME", os.getenv("USER_DB_NAME", ""))
     else:  # Local or testing environment
-        # Local settings for Movies database
-        os.environ.setdefault("MYSQL_HOST", "127.0.0.1")
-        os.environ.setdefault("MYSQL_USER", "root")
-        os.environ.setdefault("MYSQL_PASSWORD", "caching_sha2_password")
-        os.environ.setdefault("MYSQL_DB", "imdb")
-
-        # Local settings for UserAccounts database
-        os.environ.setdefault("USER_DB_HOST", "127.0.0.1")
-        os.environ.setdefault("USER_DB_USER", "root")
-        os.environ.setdefault("USER_DB_PASSWORD", "caching_sha2_password")
-        os.environ.setdefault("USER_DB_NAME", "UserAccounts")
-
-    # Output for debugging
-    print("Environment configured for:", os.getenv("FLASK_ENV"))
-    print("Movies Database Host:", os.getenv("MYSQL_HOST"))
-    print("Movies Database User:", os.getenv("MYSQL_USER"))
-    print("Movies Database Name:", os.getenv("MYSQL_DB"))
-    print("UserAccounts Database Host:", os.getenv("USER_DB_HOST"))
-    print("UserAccounts Database User:", os.getenv("USER_DB_USER"))
-    print("UserAccounts Database Name:", os.getenv("USER_DB_NAME"))
+        os.environ.setdefault("MYSQL_HOST", os.getenv("MYSQL_HOST", "127.0.0.1"))
+        os.environ.setdefault("MYSQL_USER", os.getenv("MYSQL_USER", "root"))
+        os.environ.setdefault("MYSQL_PASSWORD", os.getenv("MYSQL_PASSWORD", ""))
+        os.environ.setdefault("MYSQL_DB", os.getenv("MYSQL_DB", "imdb"))
+        os.environ.setdefault("USER_DB_HOST", os.getenv("USER_DB_HOST", "127.0.0.1"))
+        os.environ.setdefault("USER_DB_USER", os.getenv("USER_DB_USER", "root"))
+        os.environ.setdefault("USER_DB_PASSWORD", os.getenv("USER_DB_PASSWORD", ""))
+        os.environ.setdefault("USER_DB_NAME", os.getenv("USER_DB_NAME", "UserAccounts"))
 
 
 if __name__ == "__main__":

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from logging.handlers import RotatingFileHandler
 
 
@@ -11,6 +12,10 @@ def setup_logging(log_level: int = logging.INFO) -> None:
 
     file_handler = RotatingFileHandler("app.log", maxBytes=5 * 1024 * 1024, backupCount=3)
     file_handler.setFormatter(logging.Formatter(log_format))
+
+    redact_filter = RedactFilter()
+    console_handler.addFilter(redact_filter)
+    file_handler.addFilter(redact_filter)
 
     logging.basicConfig(level=log_level, handlers=[console_handler, file_handler])
 
@@ -25,4 +30,18 @@ def setup_logging(log_level: int = logging.INFO) -> None:
 def get_logger(name: str) -> logging.Logger:
     """Return a module specific logger."""
     return logging.getLogger(name)
+
+
+class RedactFilter(logging.Filter):
+    """Simple logging filter to redact common secret patterns."""
+
+    patterns = ["password", "secret", "api_key", "token"]
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        for pattern in self.patterns:
+            regex = re.compile(rf"(?i){pattern}=([^\s]+)")
+            message = regex.sub(f"{pattern}=[REDACTED]", message)
+        record.msg = message
+        return True
 

--- a/movie_service.py
+++ b/movie_service.py
@@ -12,7 +12,7 @@ from scripts.filter_backend import (
     ImdbRandomMovieFetcher,
     extract_movie_filter_criteria,
 )
-from scripts.tmdb_client import TMDbHelper, TMDB_API_KEY
+from scripts.tmdb_client import TMDbHelper
 
 logger = get_logger(__name__)
 
@@ -30,7 +30,7 @@ class MovieManager:
         self.current_displayed_movie = None
         self.default_movie_tmdb_id = 62
         self.default_backdrop_url = None
-        self.tmdb_helper = TMDbHelper(TMDB_API_KEY)  # Initialize TMDbHelper
+        self.tmdb_helper = TMDbHelper()  # Initialize TMDbHelper using env key
 
         self.user_previous_movies_stack = {}  # User-specific previous movies stack
         self.user_future_movies_stack = {}  # User-specific future movies stack

--- a/scripts/movie.py
+++ b/scripts/movie.py
@@ -9,7 +9,7 @@ import httpx
 from settings import Config, DatabaseConnectionPool
 from db_utils import DatabaseQueryExecutor
 from scripts.filter_backend import ImdbRandomMovieFetcher
-from scripts.tmdb_client import TMDbHelper
+from scripts.tmdb_client import TMDbHelper, get_tmdb_api_key
 
 # Configure logging for better debugging
 logger = get_logger(__name__)
@@ -28,11 +28,7 @@ def build_ratings_query():
     """
 
 
-# Replace with your actual TMDb API key
-TMDB_API_KEY = "1ce9398920594a5521f0d53e9b33c52f"
 TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/"
-
-# Replace with your actual TMDb API key
 TMDB_API_BASE_URL = "https://api.themoviedb.org/3"
 
 
@@ -41,9 +37,10 @@ TMDB_API_BASE_URL = "https://api.themoviedb.org/3"
 
 # Async TMDb operations
 async def get_tmdb_id_by_tconst(tconst, client):
+    api_key = get_tmdb_api_key()
     response = await client.get(
         f"{TMDB_API_BASE_URL}/find/{tconst}",
-        params={"api_key": TMDB_API_KEY, "external_source": "imdb_id"},
+        params={"api_key": api_key, "external_source": "imdb_id"},
     )
     response.raise_for_status()
     data = response.json()
@@ -95,7 +92,7 @@ class Movie:
         self.db_pool = db_pool
         self.movie_data = {}
         self.query_executor = DatabaseQueryExecutor(db_pool)
-        self.tmdb_helper = TMDbHelper(TMDB_API_KEY)  # Initialize TMDbHelper
+        self.tmdb_helper = TMDbHelper()  # Initialize TMDbHelper using env key
         self.slug = None  # Assuming slug is available at initialization
         self.client = httpx.AsyncClient()  # Initialize once and reuse
 

--- a/scripts/tmdb_client.py
+++ b/scripts/tmdb_client.py
@@ -8,31 +8,34 @@ import time
 import httpx
 import tmdbsimple as tmdb
 
-api_key = os.getenv("TMDB_API_KEY")
-tmdb.API_KEY = api_key
 
-# Replace with your actual TMDb API key
-TMDB_API_KEY = "1ce9398920594a5521f0d53e9b33c52f"
+def get_tmdb_api_key() -> str:
+    """Retrieve the TMDb API key from the environment.
+
+    Fetching the key on demand enables key rotation without changing code or
+    redeploying the application.
+    """
+    api_key = os.getenv("TMDB_API_KEY")
+    if not api_key:
+        raise RuntimeError("TMDB_API_KEY environment variable is not set")
+    return api_key
+
+
+TMDB_API_BASE_URL = "https://api.themoviedb.org/3"
 TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/"
 
-# Replace with your actual TMDb API key
-TMDB_API_BASE_URL = "https://api.themoviedb.org/3"
-
-# Use os.path.dirname to go up one level from the current script's directory
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-# Now change the working directory to the parent directory
 os.chdir(parent_dir)
 
-# Log messages will use the application's configuration
 logger = get_logger(__name__)
 
 
 class TMDbHelper:
-    def __init__(self, api_key):
-        self.api_key = api_key
-        self.base_url = "https://api.themoviedb.org/3"
-        self.image_base_url = "https://image.tmdb.org/t/p/"
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or get_tmdb_api_key()
+        tmdb.API_KEY = self.api_key
+        self.base_url = TMDB_API_BASE_URL
+        self.image_base_url = TMDB_IMAGE_BASE_URL
 
     async def _get(self, endpoint, params=None):
         if params is None:
@@ -202,7 +205,7 @@ class TmdbMovieInfo:
         tmdb.API_KEY = self.api_key
 
 
-async def main(api_key, tconst):
+async def main(api_key: str, tconst: str):
     tmdb_helper = TMDbHelper(api_key)
 
     tmdb_id = await tmdb_helper.get_tmdb_id_by_tconst(tconst)
@@ -231,8 +234,6 @@ async def main(api_key, tconst):
 
 
 if __name__ == "__main__":
-    api_key = (
-        "1ce9398920594a5521f0d53e9b33c52f"  # Replace with your actual TMDb API key
-    )
-    tconst = "tt0111161"  # Replace with the IMDb tconst you have
-    asyncio.run(main(api_key, tconst))
+    key = get_tmdb_api_key()
+    tconst = "tt0111161"  # Example IMDb ID
+    asyncio.run(main(key, tconst))

--- a/settings.py
+++ b/settings.py
@@ -43,7 +43,7 @@ class Config:
             return {
                 'host': os.getenv('DB_HOST', '127.0.0.1'),
                 'user': os.getenv('DB_USER', 'root'),
-                'password': os.getenv('DB_PASSWORD', 'caching_sha2_password'),
+                'password': os.getenv('DB_PASSWORD', ''),
                 'database': os.getenv('DB_NAME', 'imdb'),
                 'port': int(os.getenv('DB_PORT', 3306)),
             }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,18 +13,17 @@ Use the following command to run all the tests:
 :license: GPLv3, see LICENSE for more details.
 """
 
-"""
-Either place your API_KEY in the following constant:
-"""
-API_KEY = '1ce9398920594a5521f0d53e9b33c52f'
-#API_KEY = 'k_0vtefojw'
+import os
 
-"""
-or include it in a keys.py file.
-"""
-try:
-    from .keys import API_KEY, USERNAME, PASSWORD, SESSION_ID
-except ImportError:
-    pass
+"""Utilities for tests to access required credentials.
 
-__all__ = ['API_KEY', 'USERNAME', 'PASSWORD', 'SESSION_ID']
+Credentials are loaded from environment variables to avoid storing secrets in
+the repository. Tests should handle missing values gracefully.
+"""
+
+API_KEY = os.getenv("TMDB_API_KEY")
+USERNAME = os.getenv("TMDB_USERNAME")
+PASSWORD = os.getenv("TMDB_PASSWORD")
+SESSION_ID = os.getenv("TMDB_SESSION_ID")
+
+__all__ = ["API_KEY", "USERNAME", "PASSWORD", "SESSION_ID"]

--- a/tests/test_movie_service.py
+++ b/tests/test_movie_service.py
@@ -1,7 +1,11 @@
 import asyncio
 from unittest.mock import AsyncMock, patch
 
+import os
 from movie_service import MovieManager
+
+# Provide a dummy TMDb API key for tests to avoid external dependencies
+os.environ.setdefault("TMDB_API_KEY", "test_key")
 
 
 def test_start():


### PR DESCRIPTION
## Summary
- replace hard-coded TMDB API key with environment-based retrieval and helper for rotation
- add logging filter to redact secrets from console and log output
- scrub default credentials from utilities and document secure configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689253939e3c832da8aa290b1ed0c143