### PR TITLE
Store watch queue in session

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -90,7 +90,7 @@ def test_handle_new_user_route():
     async def run_test():
         with patch('app.MovieManager') as MockManager:
             manager = MockManager.return_value
-            manager.movie_queue_manager = AsyncMock(add_user=AsyncMock())
+            manager.add_user = AsyncMock()
 
             app = create_app()
             app.config['TESTING'] = True

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -1,6 +1,5 @@
 import asyncio
 from unittest.mock import AsyncMock, patch
-from types import SimpleNamespace
 
 from quart import session
 
@@ -35,9 +34,6 @@ def test_session_auto_initialization():
         with patch("app.MovieManager") as MockManager:
             manager = MockManager.return_value
             manager.add_user = AsyncMock()
-            manager.movie_queue_manager = SimpleNamespace(
-                start_populate_task=AsyncMock()
-            )
             manager.home = AsyncMock(return_value="home")
             app = create_app()
             app.config["TESTING"] = False
@@ -46,6 +42,5 @@ def test_session_auto_initialization():
                 response = await client.get("/")
                 assert response.status_code == 200
                 assert manager.add_user.called
-                assert manager.movie_queue_manager.start_populate_task.called
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Replace database-backed movie queue with session-managed lists so no watch data is persisted
- Simplify next/previous movie endpoints to use session queue and remove background tasks
- Update tests for session-based watch queue

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68925220b9f0832dab4d2f111c6041c7