### PR TITLE
Allow optional SSL verification for database connections

### DIFF
--- a/secure_pool.py
+++ b/secure_pool.py
@@ -16,62 +16,68 @@ from enum import Enum
 
 logger = logging.getLogger(__name__)
 
+
 class PoolState(Enum):
     """Connection pool states"""
+
     HEALTHY = "healthy"
     DEGRADED = "degraded"
     CRITICAL = "critical"
     FAILED = "failed"
 
+
 @dataclass
 class SecurePoolConfig:
     """Enhanced secure pool configuration"""
+
     # Connection settings
     host: str
     user: str
     password: str
     database: str
     port: int = 3306
-    
+
     # Pool size limits - More restrictive for security
-    min_size: int = 5        # Minimum connections
-    max_size: int = 20       # Maximum total connections
-    
+    min_size: int = 5  # Minimum connections
+    max_size: int = 20  # Maximum total connections
+
     # Per-user/IP limits to prevent exhaustion
-    max_connections_per_user: int = 5     # Max connections per user
-    max_connections_per_ip: int = 10      # Max connections per IP
-    
+    max_connections_per_user: int = 5  # Max connections per user
+    max_connections_per_ip: int = 10  # Max connections per IP
+
     # Connection lifecycle
-    connect_timeout: int = 5              # Connection timeout
-    query_timeout: int = 30                # Query execution timeout
-    pool_recycle: int = 900                # Recycle connections every 15 min
-    idle_timeout: int = 300                # Close idle connections after 5 min
-    
+    connect_timeout: int = 5  # Connection timeout
+    query_timeout: int = 30  # Query execution timeout
+    pool_recycle: int = 900  # Recycle connections every 15 min
+    idle_timeout: int = 300  # Close idle connections after 5 min
+
     # Rate limiting
-    max_queries_per_minute: int = 1000    # Global query rate limit
+    max_queries_per_minute: int = 1000  # Global query rate limit
     max_queries_per_user_minute: int = 100  # Per-user query rate limit
-    
+
     # Health checks
-    health_check_interval: int = 10       # Health check frequency
-    pool_pre_ping: bool = True            # Ping before using connection
-    
+    health_check_interval: int = 10  # Health check frequency
+    pool_pre_ping: bool = True  # Ping before using connection
+
     # Circuit breaker
-    circuit_breaker_threshold: int = 5    # Failures before opening
-    circuit_breaker_timeout: int = 30     # Recovery timeout
+    circuit_breaker_threshold: int = 5  # Failures before opening
+    circuit_breaker_timeout: int = 30  # Recovery timeout
     circuit_breaker_half_open_requests: int = 3  # Test requests in half-open
-    
+
     # SSL settings
     ssl_cert_path: Optional[str] = None
     use_ssl: bool = True
-    
+    validate_ssl: bool = True
+
     # Monitoring
     enable_metrics: bool = True
-    slow_query_threshold: float = 1.0     # Log queries slower than 1s
+    slow_query_threshold: float = 1.0  # Log queries slower than 1s
 
 
 @dataclass
 class ConnectionMetadata:
     """Metadata for tracking connections"""
+
     connection_id: str
     user_id: Optional[str]
     ip_address: Optional[str]
@@ -80,11 +86,11 @@ class ConnectionMetadata:
     queries_executed: int = 0
     bytes_sent: int = 0
     bytes_received: int = 0
-    
+
     def age_seconds(self) -> float:
         """Get connection age in seconds"""
         return (datetime.now() - self.created_at).total_seconds()
-    
+
     def idle_seconds(self) -> float:
         """Get idle time in seconds"""
         return (datetime.now() - self.last_used_at).total_seconds()
@@ -92,14 +98,14 @@ class ConnectionMetadata:
 
 class RateLimiter:
     """Token bucket rate limiter"""
-    
+
     def __init__(self, rate: int, burst: int = None):
         self.rate = rate  # Tokens per minute
         self.burst = burst or rate
         self.tokens = self.burst
         self.last_refill = time.time()
         self.lock = asyncio.Lock()
-    
+
     async def acquire(self, tokens: int = 1) -> bool:
         """Try to acquire tokens"""
         async with self.lock:
@@ -109,7 +115,7 @@ class RateLimiter:
             refill = elapsed * (self.rate / 60.0)
             self.tokens = min(self.burst, self.tokens + refill)
             self.last_refill = now
-            
+
             # Check if we have enough tokens
             if self.tokens >= tokens:
                 self.tokens -= tokens
@@ -119,66 +125,68 @@ class RateLimiter:
 
 class SecureConnectionPool:
     """Production-ready secure connection pool with resource protection"""
-    
+
     def __init__(self, config: SecurePoolConfig):
         self.config = config
         self.pool: Optional[Pool] = None
         self.state = PoolState.HEALTHY
-        
+
         # Connection tracking
         self.connections: Dict[int, ConnectionMetadata] = {}
         self.user_connections: Dict[str, Set[int]] = defaultdict(set)
         self.ip_connections: Dict[str, Set[int]] = defaultdict(set)
-        
+
         # Rate limiting
         self.global_rate_limiter = RateLimiter(config.max_queries_per_minute)
         self.user_rate_limiters: Dict[str, RateLimiter] = {}
-        
+
         # Metrics
         self.metrics = {
-            'total_connections': 0,
-            'active_connections': 0,
-            'idle_connections': 0,
-            'connections_created': 0,
-            'connections_closed': 0,
-            'connections_recycled': 0,
-            'connections_failed': 0,
-            'queries_executed': 0,
-            'queries_failed': 0,
-            'queries_slow': 0,
-            'rate_limit_hits': 0,
-            'circuit_breaker_trips': 0,
-            'health_check_failures': 0
+            "total_connections": 0,
+            "active_connections": 0,
+            "idle_connections": 0,
+            "connections_created": 0,
+            "connections_closed": 0,
+            "connections_recycled": 0,
+            "connections_failed": 0,
+            "queries_executed": 0,
+            "queries_failed": 0,
+            "queries_slow": 0,
+            "rate_limit_hits": 0,
+            "circuit_breaker_trips": 0,
+            "health_check_failures": 0,
         }
-        
+
         # Query history for monitoring
         self.recent_queries: deque = deque(maxlen=100)
         self.slow_queries: deque = deque(maxlen=50)
-        
+
         # Circuit breaker
         self.circuit_breaker_failures = 0
         self.circuit_breaker_last_failure = None
         self.circuit_breaker_state = "closed"
-        
+
         # Tasks
         self._health_check_task: Optional[asyncio.Task] = None
         self._cleanup_task: Optional[asyncio.Task] = None
         self._shutdown = False
-    
+
     async def init_pool(self):
         """Initialize the secure connection pool"""
         if self.circuit_breaker_state == "open":
             if not self._can_attempt_reconnect():
                 raise Exception("Circuit breaker is open")
-        
+
         try:
-            logger.info(f"Initializing secure pool: {self.config.host}:{self.config.port}")
-            
+            logger.info(
+                f"Initializing secure pool: {self.config.host}:{self.config.port}"
+            )
+
             # Create SSL context if needed
             ssl_context = None
-            if self.config.use_ssl and self.config.ssl_cert_path:
+            if self.config.use_ssl:
                 ssl_context = self._create_ssl_context()
-            
+
             # Create pool with security limits
             self.pool = await aiomysql.create_pool(
                 host=self.config.host,
@@ -193,244 +201,266 @@ class SecureConnectionPool:
                 cursorclass=DictCursor,
                 pool_recycle=self.config.pool_recycle,
                 echo=False,
-                autocommit=False
+                autocommit=False,
             )
-            
+
             # Validate pool
             await self._validate_pool()
-            
+
             # Start monitoring tasks
             self._health_check_task = asyncio.create_task(self._health_monitor())
             self._cleanup_task = asyncio.create_task(self._connection_cleanup())
-            
+
             # Reset circuit breaker
             self.circuit_breaker_state = "closed"
             self.circuit_breaker_failures = 0
-            
+
             self.state = PoolState.HEALTHY
             logger.info("Secure connection pool initialized successfully")
-            
+
         except Exception as e:
             self._record_circuit_breaker_failure()
             logger.error(f"Failed to initialize pool: {e}")
             raise
-    
+
     def _create_ssl_context(self) -> ssl.SSLContext:
         """Create secure SSL context"""
-        context = ssl.create_default_context(cafile=self.config.ssl_cert_path)
+        if self.config.validate_ssl and self.config.ssl_cert_path:
+            context = ssl.create_default_context(cafile=self.config.ssl_cert_path)
+        else:
+            context = ssl.create_default_context()
         context.check_hostname = False
-        context.verify_mode = ssl.CERT_REQUIRED
+        context.verify_mode = (
+            ssl.CERT_REQUIRED if self.config.validate_ssl else ssl.CERT_NONE
+        )
         context.minimum_version = ssl.TLSVersion.TLSv1_2
-        context.set_ciphers('ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20:!aNULL:!MD5:!DSS')
+        context.set_ciphers(
+            "ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20:!aNULL:!MD5:!DSS"
+        )
         return context
-    
+
     async def _validate_pool(self):
         """Validate pool connectivity"""
         async with self.acquire(user_id="system", ip_address="127.0.0.1") as conn:
             async with conn.cursor() as cursor:
                 await cursor.execute("SELECT 1")
                 result = await cursor.fetchone()
-                if result != {'1': 1}:
+                if result != {"1": 1}:
                     raise Exception("Pool validation failed")
-    
+
     def _check_user_limit(self, user_id: str) -> bool:
         """Check if user has reached connection limit"""
         active_count = len(self.user_connections.get(user_id, set()))
         return active_count < self.config.max_connections_per_user
-    
+
     def _check_ip_limit(self, ip_address: str) -> bool:
         """Check if IP has reached connection limit"""
         active_count = len(self.ip_connections.get(ip_address, set()))
         return active_count < self.config.max_connections_per_ip
-    
+
     async def _check_rate_limit(self, user_id: str) -> bool:
         """Check rate limits"""
         # Global rate limit
         if not await self.global_rate_limiter.acquire():
-            self.metrics['rate_limit_hits'] += 1
+            self.metrics["rate_limit_hits"] += 1
             return False
-        
+
         # User rate limit
         if user_id and user_id != "system":
             if user_id not in self.user_rate_limiters:
                 self.user_rate_limiters[user_id] = RateLimiter(
                     self.config.max_queries_per_user_minute
                 )
-            
+
             if not await self.user_rate_limiters[user_id].acquire():
-                self.metrics['rate_limit_hits'] += 1
+                self.metrics["rate_limit_hits"] += 1
                 return False
-        
+
         return True
-    
+
     @asynccontextmanager
-    async def acquire(self, user_id: str = None, ip_address: str = None) -> AsyncIterator[Connection]:
+    async def acquire(
+        self, user_id: str = None, ip_address: str = None
+    ) -> AsyncIterator[Connection]:
         """Acquire a connection with security checks"""
         # Check circuit breaker
         if self.circuit_breaker_state == "open":
             if not self._can_attempt_reconnect():
                 raise Exception("Circuit breaker is open - pool unavailable")
-        
+
         # Check user/IP limits
         if user_id and not self._check_user_limit(user_id):
             raise Exception(f"User {user_id} has reached connection limit")
-        
+
         if ip_address and not self._check_ip_limit(ip_address):
             raise Exception(f"IP {ip_address} has reached connection limit")
-        
+
         # Check rate limits
         if not await self._check_rate_limit(user_id):
             raise Exception("Rate limit exceeded")
-        
+
         connection = None
         conn_id = None
-        
+
         try:
             # Acquire connection with timeout
             connection = await asyncio.wait_for(
-                self.pool.acquire(),
-                timeout=self.config.connect_timeout
+                self.pool.acquire(), timeout=self.config.connect_timeout
             )
-            
+
             conn_id = id(connection)
-            
+
             # Track connection
             metadata = ConnectionMetadata(
                 connection_id=hashlib.md5(str(conn_id).encode()).hexdigest()[:8],
                 user_id=user_id,
                 ip_address=ip_address,
                 created_at=datetime.now(),
-                last_used_at=datetime.now()
+                last_used_at=datetime.now(),
             )
             self.connections[conn_id] = metadata
-            
+
             if user_id:
                 self.user_connections[user_id].add(conn_id)
             if ip_address:
                 self.ip_connections[ip_address].add(conn_id)
-            
-            self.metrics['active_connections'] += 1
-            
+
+            self.metrics["active_connections"] += 1
+
             # Ping if configured
             if self.config.pool_pre_ping:
                 await connection.ping()
-            
+
             # Reset circuit breaker on success
             if self.circuit_breaker_state == "half-open":
                 self.circuit_breaker_state = "closed"
                 self.circuit_breaker_failures = 0
-            
+
             yield connection
-            
+
         except asyncio.TimeoutError:
-            self.metrics['connections_failed'] += 1
+            self.metrics["connections_failed"] += 1
             self._record_circuit_breaker_failure()
             raise Exception("Connection acquisition timeout")
-            
+
         except Exception as e:
-            self.metrics['connections_failed'] += 1
+            self.metrics["connections_failed"] += 1
             self._record_circuit_breaker_failure()
             logger.error(f"Connection acquisition failed: {e}")
             raise
-            
+
         finally:
             if connection and conn_id:
                 # Update metadata
                 if conn_id in self.connections:
                     self.connections[conn_id].last_used_at = datetime.now()
                     self.connections[conn_id].queries_executed += 1
-                
+
                 # Clean up tracking
                 if user_id and conn_id in self.user_connections[user_id]:
                     self.user_connections[user_id].discard(conn_id)
                 if ip_address and conn_id in self.ip_connections[ip_address]:
                     self.ip_connections[ip_address].discard(conn_id)
-                
+
                 del self.connections[conn_id]
-                self.metrics['active_connections'] -= 1
-                
+                self.metrics["active_connections"] -= 1
+
                 # Release connection
                 self.pool.release(connection)
-    
-    async def execute_secure(self, query: str, params: tuple = None, 
-                            user_id: str = None, ip_address: str = None,
-                            fetch: str = 'one') -> Any:
+
+    async def execute_secure(
+        self,
+        query: str,
+        params: tuple = None,
+        user_id: str = None,
+        ip_address: str = None,
+        fetch: str = "one",
+    ) -> Any:
         """Execute query with security controls"""
         start_time = time.time()
-        
+
         try:
-            async with self.acquire(user_id=user_id, ip_address=ip_address) as connection:
+            async with self.acquire(
+                user_id=user_id, ip_address=ip_address
+            ) as connection:
                 async with connection.cursor() as cursor:
                     # Execute with timeout
                     await asyncio.wait_for(
-                        cursor.execute(query, params),
-                        timeout=self.config.query_timeout
+                        cursor.execute(query, params), timeout=self.config.query_timeout
                     )
-                    
+
                     # Fetch results
-                    if fetch == 'one':
+                    if fetch == "one":
                         result = await cursor.fetchone()
-                    elif fetch == 'all':
+                    elif fetch == "all":
                         result = await cursor.fetchall()
-                    elif fetch == 'many':
+                    elif fetch == "many":
                         result = await cursor.fetchmany()
                     else:
                         result = cursor.rowcount
-                    
+
                     # Track metrics
                     query_time = time.time() - start_time
-                    self.metrics['queries_executed'] += 1
-                    
+                    self.metrics["queries_executed"] += 1
+
                     # Track slow queries
                     if query_time > self.config.slow_query_threshold:
-                        self.metrics['queries_slow'] += 1
-                        self.slow_queries.append({
-                            'query': query[:100],
-                            'duration': query_time,
-                            'user_id': user_id,
-                            'timestamp': datetime.now()
-                        })
-                        logger.warning(f"Slow query ({query_time:.2f}s): {query[:50]}...")
-                    
+                        self.metrics["queries_slow"] += 1
+                        self.slow_queries.append(
+                            {
+                                "query": query[:100],
+                                "duration": query_time,
+                                "user_id": user_id,
+                                "timestamp": datetime.now(),
+                            }
+                        )
+                        logger.warning(
+                            f"Slow query ({query_time:.2f}s): {query[:50]}..."
+                        )
+
                     # Track recent queries
-                    self.recent_queries.append({
-                        'query': query[:50],
-                        'duration': query_time,
-                        'user_id': user_id,
-                        'timestamp': datetime.now()
-                    })
-                    
+                    self.recent_queries.append(
+                        {
+                            "query": query[:50],
+                            "duration": query_time,
+                            "user_id": user_id,
+                            "timestamp": datetime.now(),
+                        }
+                    )
+
                     return result
-                    
+
         except asyncio.TimeoutError:
-            self.metrics['queries_failed'] += 1
+            self.metrics["queries_failed"] += 1
             raise Exception(f"Query timeout after {self.config.query_timeout}s")
-            
+
         except Exception as e:
-            self.metrics['queries_failed'] += 1
+            self.metrics["queries_failed"] += 1
             logger.error(f"Query execution failed: {e}")
             raise
-    
+
     async def _health_monitor(self):
         """Monitor pool health"""
         while not self._shutdown:
             try:
                 await asyncio.sleep(self.config.health_check_interval)
-                
+
                 # Check pool state
                 if not self.pool:
                     self.state = PoolState.FAILED
                     continue
-                
+
                 pool_size = self.pool.size
                 free_size = self.pool.freesize
-                
+
                 # Update metrics
-                self.metrics['idle_connections'] = free_size
-                
+                self.metrics["idle_connections"] = free_size
+
                 # Determine health state
-                usage_percent = (pool_size - free_size) / pool_size * 100 if pool_size > 0 else 0
-                
+                usage_percent = (
+                    (pool_size - free_size) / pool_size * 100 if pool_size > 0 else 0
+                )
+
                 if usage_percent > 90:
                     self.state = PoolState.CRITICAL
                     logger.warning(f"Pool critical: {usage_percent:.1f}% usage")
@@ -439,28 +469,30 @@ class SecureConnectionPool:
                     logger.warning(f"Pool degraded: {usage_percent:.1f}% usage")
                 else:
                     self.state = PoolState.HEALTHY
-                
+
                 # Test connectivity
                 try:
-                    async with self.acquire(user_id="system", ip_address="127.0.0.1") as conn:
+                    async with self.acquire(
+                        user_id="system", ip_address="127.0.0.1"
+                    ) as conn:
                         async with conn.cursor() as cursor:
                             await cursor.execute("SELECT 1")
                             await cursor.fetchone()
                 except Exception as e:
-                    self.metrics['health_check_failures'] += 1
+                    self.metrics["health_check_failures"] += 1
                     logger.error(f"Health check failed: {e}")
-                    
+
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.error(f"Health monitor error: {e}")
-    
+
     async def _connection_cleanup(self):
         """Clean up idle and old connections"""
         while not self._shutdown:
             try:
                 await asyncio.sleep(30)  # Run every 30 seconds
-                
+
                 # Clean up idle connections
                 now = datetime.now()
                 for conn_id, metadata in list(self.connections.items()):
@@ -468,73 +500,75 @@ class SecureConnectionPool:
                     if metadata.idle_seconds() > self.config.idle_timeout:
                         logger.info(f"Closing idle connection {metadata.connection_id}")
                         # Connection will be cleaned up when released
-                        
+
                     # Check max age (pool_recycle)
                     if metadata.age_seconds() > self.config.pool_recycle:
-                        logger.info(f"Recycling old connection {metadata.connection_id}")
-                        self.metrics['connections_recycled'] += 1
-                        
+                        logger.info(
+                            f"Recycling old connection {metadata.connection_id}"
+                        )
+                        self.metrics["connections_recycled"] += 1
+
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.error(f"Cleanup error: {e}")
-    
+
     def _record_circuit_breaker_failure(self):
         """Record a circuit breaker failure"""
         self.circuit_breaker_failures += 1
         self.circuit_breaker_last_failure = datetime.now()
-        
+
         if self.circuit_breaker_failures >= self.config.circuit_breaker_threshold:
             if self.circuit_breaker_state != "open":
                 self.circuit_breaker_state = "open"
-                self.metrics['circuit_breaker_trips'] += 1
+                self.metrics["circuit_breaker_trips"] += 1
                 logger.error("Circuit breaker opened due to repeated failures")
-    
+
     def _can_attempt_reconnect(self) -> bool:
         """Check if we can attempt reconnection"""
         if self.circuit_breaker_state != "open":
             return True
-            
+
         if self.circuit_breaker_last_failure:
             elapsed = (datetime.now() - self.circuit_breaker_last_failure).seconds
             if elapsed > self.config.circuit_breaker_timeout:
                 self.circuit_breaker_state = "half-open"
                 logger.info("Circuit breaker entering half-open state")
                 return True
-        
+
         return False
-    
+
     async def get_pool_status(self) -> Dict[str, Any]:
         """Get detailed pool status"""
         return {
-            'state': self.state.value,
-            'pool_size': self.pool.size if self.pool else 0,
-            'free_connections': self.pool.freesize if self.pool else 0,
-            'active_connections': self.metrics['active_connections'],
-            'idle_connections': self.metrics['idle_connections'],
-            'total_connections_created': self.metrics['connections_created'],
-            'total_connections_failed': self.metrics['connections_failed'],
-            'total_connections_recycled': self.metrics['connections_recycled'],
-            'queries_executed': self.metrics['queries_executed'],
-            'queries_failed': self.metrics['queries_failed'],
-            'slow_queries': self.metrics['queries_slow'],
-            'rate_limit_hits': self.metrics['rate_limit_hits'],
-            'circuit_breaker_state': self.circuit_breaker_state,
-            'circuit_breaker_trips': self.metrics['circuit_breaker_trips'],
-            'health_check_failures': self.metrics['health_check_failures'],
-            'user_connection_counts': {
+            "state": self.state.value,
+            "pool_size": self.pool.size if self.pool else 0,
+            "free_connections": self.pool.freesize if self.pool else 0,
+            "active_connections": self.metrics["active_connections"],
+            "idle_connections": self.metrics["idle_connections"],
+            "total_connections_created": self.metrics["connections_created"],
+            "total_connections_failed": self.metrics["connections_failed"],
+            "total_connections_recycled": self.metrics["connections_recycled"],
+            "queries_executed": self.metrics["queries_executed"],
+            "queries_failed": self.metrics["queries_failed"],
+            "slow_queries": self.metrics["queries_slow"],
+            "rate_limit_hits": self.metrics["rate_limit_hits"],
+            "circuit_breaker_state": self.circuit_breaker_state,
+            "circuit_breaker_trips": self.metrics["circuit_breaker_trips"],
+            "health_check_failures": self.metrics["health_check_failures"],
+            "user_connection_counts": {
                 user: len(conns) for user, conns in self.user_connections.items()
             },
-            'ip_connection_counts': {
+            "ip_connection_counts": {
                 ip: len(conns) for ip, conns in self.ip_connections.items()
             },
-            'recent_slow_queries': list(self.slow_queries)[-10:]
+            "recent_slow_queries": list(self.slow_queries)[-10:],
         }
-    
+
     async def close_pool(self):
         """Gracefully close the pool"""
         self._shutdown = True
-        
+
         # Cancel monitoring tasks
         if self._health_check_task:
             self._health_check_task.cancel()
@@ -542,14 +576,14 @@ class SecureConnectionPool:
                 await self._health_check_task
             except asyncio.CancelledError:
                 pass
-        
+
         if self._cleanup_task:
             self._cleanup_task.cancel()
             try:
                 await self._cleanup_task
             except asyncio.CancelledError:
                 pass
-        
+
         # Close pool
         if self.pool:
             self.pool.close()

--- a/settings.py
+++ b/settings.py
@@ -10,18 +10,15 @@ from secrets_manager import secrets_manager
 
 logger = get_logger(__name__)
 
-flask_env = os.getenv('FLASK_ENV', 'development')
+flask_env = os.getenv("FLASK_ENV", "development")
 # Determine which .env file to load based on FLASK_ENV
 # flask_env = os.getenv('FLASK_ENV', 'production')
 logger.debug("FLASK_ENV is set to: %s", flask_env)
 
-env_file = '.env.development' if flask_env == 'development' else '.env'
+env_file = ".env.development" if flask_env == "development" else ".env"
 load_dotenv(dotenv_path=env_file)
 logger.debug("Loaded .env file: %s", env_file)
-logger.debug("Database Host from environment: %s", os.getenv('DB_HOST'))
-
-
-
+logger.debug("Database Host from environment: %s", os.getenv("DB_HOST"))
 
 
 class Config:
@@ -29,87 +26,105 @@ class Config:
     @staticmethod
     def get_flask_secret_key():
         """Get Flask secret key from secure source."""
-        return secrets_manager.get_secret('FLASK_SECRET_KEY')
-    
+        return secrets_manager.get_secret("FLASK_SECRET_KEY")
+
     @staticmethod
     def get_tmdb_api_key():
         """Get TMDB API key from secure source."""
-        return secrets_manager.get_secret('TMDB_API_KEY')
-    
+        return secrets_manager.get_secret("TMDB_API_KEY")
+
     # Dynamic properties for backward compatibility
     @property
     def SECRET_KEY(self):
         return self.get_flask_secret_key()
-    
+
     @property
     def TMDB_API_KEY(self):
         return self.get_tmdb_api_key()
 
     # Session Security Configuration
-    SECRET_KEY = secrets_manager.get_secret('FLASK_SECRET_KEY')
-    
-    # Session Cookie Security  
-    SESSION_COOKIE_NAME = 'session'
+    SECRET_KEY = secrets_manager.get_secret("FLASK_SECRET_KEY")
+
+    # Session Cookie Security
+    SESSION_COOKIE_NAME = "session"
     SESSION_COOKIE_HTTPONLY = True
-    SESSION_COOKIE_SAMESITE = 'Lax'  # or 'Strict' for higher security
-    
+    SESSION_COOKIE_SAMESITE = "Lax"  # or 'Strict' for higher security
+
     # Force HTTPS in production
     @property
     def SESSION_COOKIE_SECURE(self):
         """Enable secure cookies in production."""
-        env = os.getenv('FLASK_ENV', 'development')
-        secure = env != 'development'
-        if env == 'production' and not secure:
+        env = os.getenv("FLASK_ENV", "development")
+        secure = env != "development"
+        if env == "production" and not secure:
             logger.error("WARNING: Secure cookies disabled in production!")
         return secure
-    
+
     # Additional security headers
-    SESSION_COOKIE_DOMAIN = None if os.getenv('FLASK_ENV') != 'production' else os.getenv('COOKIE_DOMAIN', None)
-    
+    SESSION_COOKIE_DOMAIN = (
+        None
+        if os.getenv("FLASK_ENV") != "production"
+        else os.getenv("COOKIE_DOMAIN", None)
+    )
+
     # Session timeouts
-    SESSION_TIMEOUT_MINUTES = int(os.getenv('SESSION_TIMEOUT_MINUTES', 30))
-    SESSION_IDLE_TIMEOUT_MINUTES = int(os.getenv('SESSION_IDLE_TIMEOUT_MINUTES', 15))
-    SESSION_ROTATION_INTERVAL = int(os.getenv('SESSION_ROTATION_INTERVAL', 10))
-    MAX_SESSION_DURATION_HOURS = int(os.getenv('MAX_SESSION_DURATION_HOURS', 24))
-    
+    SESSION_TIMEOUT_MINUTES = int(os.getenv("SESSION_TIMEOUT_MINUTES", 30))
+    SESSION_IDLE_TIMEOUT_MINUTES = int(os.getenv("SESSION_IDLE_TIMEOUT_MINUTES", 15))
+    SESSION_ROTATION_INTERVAL = int(os.getenv("SESSION_ROTATION_INTERVAL", 10))
+    MAX_SESSION_DURATION_HOURS = int(os.getenv("MAX_SESSION_DURATION_HOURS", 24))
+
     # Redis session configuration
-    SESSION_TYPE = 'redis'
+    SESSION_TYPE = "redis"
     SESSION_PERMANENT = False
     SESSION_USE_SIGNER = False
-    SESSION_KEY_PREFIX = 'session:'
+    SESSION_KEY_PREFIX = "session:"
     PERMANENT_SESSION_LIFETIME = 86400  # 24 hours in seconds
 
     # Expose production database configuration for scripts that need it
     STACKHERO_DB_CONFIG = {
-        'host': os.getenv('STACKHERO_DB_HOST'),
-        'user': os.getenv('STACKHERO_DB_USER'),
-        'password': os.getenv('STACKHERO_DB_PASSWORD'),
-        'database': os.getenv('STACKHERO_DB_NAME'),
-        'port': int(os.getenv('STACKHERO_DB_PORT', 3306)),
+        "host": os.getenv("STACKHERO_DB_HOST"),
+        "user": os.getenv("STACKHERO_DB_USER"),
+        "password": os.getenv("STACKHERO_DB_PASSWORD"),
+        "database": os.getenv("STACKHERO_DB_NAME"),
+        "port": int(os.getenv("STACKHERO_DB_PORT", 3306)),
     }
 
     # Dynamically switch database configurations based on FLASK_ENV
     @staticmethod
     def get_db_config():
         """Get database configuration based on environment"""
-        if flask_env == 'development':
+        if flask_env == "development":
             # Development configuration - local MySQL
             return {
-                'host': os.getenv('DB_HOST', '127.0.0.1'),
-                'user': os.getenv('DB_USER', 'root'),
-                'password': os.getenv('DB_PASSWORD', ''),
-                'database': os.getenv('DB_NAME', 'imdb'),
-                'port': int(os.getenv('DB_PORT', 3306)),
+                "host": os.getenv("DB_HOST", "127.0.0.1"),
+                "user": os.getenv("DB_USER", "root"),
+                "password": os.getenv("DB_PASSWORD", ""),
+                "database": os.getenv("DB_NAME", "imdb"),
+                "port": int(os.getenv("DB_PORT", 3306)),
             }
         else:
             # Production configuration - use production database variables
             # These can be your cloud provider's database or any production MySQL
             return {
-                'host': os.getenv('PROD_DB_HOST', os.getenv('STACKHERO_DB_HOST', os.getenv('DB_HOST'))),
-                'user': os.getenv('PROD_DB_USER', os.getenv('STACKHERO_DB_USER', os.getenv('DB_USER'))),
-                'password': os.getenv('PROD_DB_PASSWORD', os.getenv('STACKHERO_DB_PASSWORD', os.getenv('DB_PASSWORD'))),
-                'database': os.getenv('PROD_DB_NAME', os.getenv('STACKHERO_DB_NAME', os.getenv('DB_NAME'))),
-                'port': int(os.getenv('PROD_DB_PORT', os.getenv('STACKHERO_DB_PORT', os.getenv('DB_PORT', 3306)))),
+                "host": os.getenv(
+                    "PROD_DB_HOST", os.getenv("STACKHERO_DB_HOST", os.getenv("DB_HOST"))
+                ),
+                "user": os.getenv(
+                    "PROD_DB_USER", os.getenv("STACKHERO_DB_USER", os.getenv("DB_USER"))
+                ),
+                "password": os.getenv(
+                    "PROD_DB_PASSWORD",
+                    os.getenv("STACKHERO_DB_PASSWORD", os.getenv("DB_PASSWORD")),
+                ),
+                "database": os.getenv(
+                    "PROD_DB_NAME", os.getenv("STACKHERO_DB_NAME", os.getenv("DB_NAME"))
+                ),
+                "port": int(
+                    os.getenv(
+                        "PROD_DB_PORT",
+                        os.getenv("STACKHERO_DB_PORT", os.getenv("DB_PORT", 3306)),
+                    )
+                ),
             }
 
     # SSL Certificate Path
@@ -124,7 +139,7 @@ class Config:
     # SSL usage based on environment
     @staticmethod
     def use_ssl():
-        return flask_env != 'development'
+        return flask_env != "development"
 
 
 import asyncio
@@ -142,6 +157,7 @@ import atexit
 @dataclass
 class PoolConfig:
     """Database pool configuration"""
+
     # Connection settings (required fields first)
     host: str
     user: str
@@ -149,29 +165,29 @@ class PoolConfig:
     database: str
     # Optional connection settings
     port: int = 3306
-    
+
     # Pool settings - Optimized for performance
     min_size: int = 10
     max_size: int = 30
-    
+
     # Connection lifecycle - Optimized timeouts
     connect_timeout: int = 5  # Reduced from 10 for faster failure
     pool_recycle: int = 1800  # Reduced from 3600 (30 min instead of 1 hour)
     echo: bool = False
-    
+
     # Health checks - More frequent for better reliability
     pool_pre_ping: bool = True
     ping_interval: int = 15  # Reduced from 30 for better detection
-    
+
     # Retry settings - Faster failure recovery
     max_retries: int = 2  # Reduced from 3 for faster failure
     retry_delay: float = 0.5
     retry_backoff: float = 2.0
-    
+
     # Circuit breaker - More responsive
     circuit_breaker_threshold: int = 3  # Reduced from 5 for faster protection
-    circuit_breaker_timeout: int = 30   # Reduced from 60 for faster recovery
-    
+    circuit_breaker_timeout: int = 30  # Reduced from 60 for faster recovery
+
     # SSL settings
     ssl_cert_path: Optional[str] = None
     use_ssl: bool = False
@@ -180,58 +196,59 @@ class PoolConfig:
 @dataclass
 class PoolMetrics:
     """Connection pool metrics"""
+
     connections_created: int = 0
     connections_closed: int = 0
     connections_recycled: int = 0
     connections_failed: int = 0
-    
+
     queries_executed: int = 0
     queries_failed: int = 0
-    
+
     active_connections: int = 0
     idle_connections: int = 0
-    
+
     health_checks_passed: int = 0
     health_checks_failed: int = 0
-    
+
     circuit_breaker_trips: int = 0
-    
+
     avg_query_time: float = 0.0
     max_query_time: float = 0.0
-    
+
     last_error: Optional[str] = None
     last_error_time: Optional[datetime] = None
 
 
 class CircuitBreaker:
     """Circuit breaker for database failures"""
-    
+
     def __init__(self, threshold: int = 5, timeout: int = 60):
         self.threshold = threshold
         self.timeout = timeout
         self.failure_count = 0
         self.last_failure_time = None
         self.state = "closed"  # closed, open, half-open
-        
+
     def record_success(self):
         """Record a successful operation"""
         self.failure_count = 0
         self.state = "closed"
-        
+
     def record_failure(self):
         """Record a failed operation"""
         self.failure_count += 1
         self.last_failure_time = datetime.now()
-        
+
         if self.failure_count >= self.threshold:
             self.state = "open"
             logger.error(f"Circuit breaker opened after {self.failure_count} failures")
-            
+
     def is_open(self) -> bool:
         """Check if circuit is open"""
         if self.state == "closed":
             return False
-            
+
         if self.state == "open":
             # Check if timeout has passed
             if self.last_failure_time:
@@ -241,7 +258,7 @@ class CircuitBreaker:
                     logger.info("Circuit breaker entering half-open state")
                     return False
             return True
-            
+
         return False
 
 
@@ -250,7 +267,7 @@ def _create_ssl_context(ssl_cert_path):
     try:
         # If no certificate path, use system defaults
         if not ssl_cert_path or not os.path.isfile(ssl_cert_path):
-            if flask_env == 'production':
+            if flask_env == "production":
                 # In production, try system certificates
                 context = ssl.create_default_context()
                 logger.info("Using system default SSL certificates")
@@ -262,81 +279,93 @@ def _create_ssl_context(ssl_cert_path):
             # Use provided certificate
             context = ssl.create_default_context(cafile=ssl_cert_path)
             logger.info(f"Using SSL certificate: {ssl_cert_path}")
-        
+
         # Configure context for MySQL
         context.check_hostname = False  # MySQL doesn't use hostname verification
-        
+
         # Set verification mode based on environment
-        if flask_env == 'production':
+        if flask_env == "production":
             context.verify_mode = ssl.CERT_REQUIRED
         else:
             # In development, make SSL optional
             context.verify_mode = ssl.CERT_NONE
-            
+
         # Set minimum TLS version to 1.2
         context.minimum_version = ssl.TLSVersion.TLSv1_2
-        
+
         # Use strong ciphers only
-        context.set_ciphers('ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20:!aNULL:!MD5:!DSS')
-        
+        context.set_ciphers(
+            "ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20:!aNULL:!MD5:!DSS"
+        )
+
         logger.info("SSL context created with enhanced security settings")
         return context
-        
+
     except Exception as e:
         logger.error("Failed to create SSL context: %s", e)
-        if flask_env == 'production':
+        if flask_env == "production":
             raise  # Re-raise in production
         return None  # Continue without SSL in development
 
 
 from secure_pool import SecureConnectionPool, SecurePoolConfig
 
+
 class DatabaseConnectionPool:
     """Wrapper for backward compatibility with secure pool"""
-    
+
     def __init__(self, db_config):
         # Convert to secure pool config
-        self.secure_config = SecurePoolConfig(
-            host=db_config['host'],
-            port=db_config.get('port', 3306),
-            user=db_config['user'],
-            password=db_config['password'],
-            database=db_config['database'],
-            min_size=int(os.getenv('POOL_MIN_SIZE', 5)),
-            max_size=int(os.getenv('POOL_MAX_SIZE', 20)),
-            max_connections_per_user=int(os.getenv('MAX_CONN_PER_USER', 10)),
-            max_connections_per_ip=int(os.getenv('MAX_CONN_PER_IP', 20)),
-            connect_timeout=int(os.getenv('DB_CONNECT_TIMEOUT', 5)),
-            query_timeout=int(os.getenv('DB_QUERY_TIMEOUT', 30)),
-            pool_recycle=int(os.getenv('DB_POOL_RECYCLE', 900)),
-            idle_timeout=int(os.getenv('DB_IDLE_TIMEOUT', 300)),
-            max_queries_per_minute=int(os.getenv('MAX_QUERIES_PER_MIN', 5000)),
-            max_queries_per_user_minute=int(os.getenv('MAX_USER_QUERIES_PER_MIN', 500)),
-            ssl_cert_path=Config.get_ssl_cert_path() if hasattr(Config, 'get_ssl_cert_path') else None,
-            use_ssl=Config.use_ssl() if hasattr(Config, 'use_ssl') else (flask_env == 'production'),
-            slow_query_threshold=float(os.getenv('SLOW_QUERY_THRESHOLD', 1.0))
+        validate_ssl = os.getenv("VALIDATE_SSL", "false").lower() == "true"
+        ssl_cert = (
+            Config.get_ssl_cert_path()
+            if validate_ssl and hasattr(Config, "get_ssl_cert_path")
+            else None
         )
-        
+        self.secure_config = SecurePoolConfig(
+            host=db_config["host"],
+            port=db_config.get("port", 3306),
+            user=db_config["user"],
+            password=db_config["password"],
+            database=db_config["database"],
+            min_size=int(os.getenv("POOL_MIN_SIZE", 5)),
+            max_size=int(os.getenv("POOL_MAX_SIZE", 20)),
+            max_connections_per_user=int(os.getenv("MAX_CONN_PER_USER", 10)),
+            max_connections_per_ip=int(os.getenv("MAX_CONN_PER_IP", 20)),
+            connect_timeout=int(os.getenv("DB_CONNECT_TIMEOUT", 5)),
+            query_timeout=int(os.getenv("DB_QUERY_TIMEOUT", 30)),
+            pool_recycle=int(os.getenv("DB_POOL_RECYCLE", 900)),
+            idle_timeout=int(os.getenv("DB_IDLE_TIMEOUT", 300)),
+            max_queries_per_minute=int(os.getenv("MAX_QUERIES_PER_MIN", 5000)),
+            max_queries_per_user_minute=int(os.getenv("MAX_USER_QUERIES_PER_MIN", 500)),
+            ssl_cert_path=ssl_cert,
+            use_ssl=Config.use_ssl()
+            if hasattr(Config, "use_ssl")
+            else (flask_env == "production"),
+            validate_ssl=validate_ssl,
+            slow_query_threshold=float(os.getenv("SLOW_QUERY_THRESHOLD", 1.0)),
+        )
+
         self.pool = SecureConnectionPool(self.secure_config)
-    
+
     async def init_pool(self):
         """Initialize the pool"""
         await self.pool.init_pool()
-    
+
     async def acquire(self, user_id=None, ip_address=None):
         """Acquire a connection"""
         return self.pool.acquire(user_id=user_id, ip_address=ip_address)
-    
-    async def execute(self, query, params=None, fetch='one', user_id=None):
+
+    async def execute(self, query, params=None, fetch="one", user_id=None):
         """Execute a query"""
         return await self.pool.execute_secure(
             query, params, user_id=user_id, fetch=fetch
         )
-    
+
     async def close_pool(self):
         """Close the pool"""
         await self.pool.close_pool()
-    
+
     async def get_metrics(self):
         """Get pool metrics"""
         return await self.pool.get_pool_status()
@@ -362,6 +391,7 @@ class DatabaseConnectionPool:
 # Global pool instance management
 _pool = None
 
+
 async def init_pool():
     """Initialize the global database connection pool."""
     global _pool
@@ -372,12 +402,14 @@ async def init_pool():
         logger.info("Global database pool initialized")
     return _pool
 
+
 async def get_pool():
     """Get the global database connection pool, initializing if needed."""
     global _pool
     if _pool is None:
         await init_pool()
     return _pool
+
 
 async def close_pool():
     """Close the global database connection pool gracefully."""
@@ -390,6 +422,7 @@ async def close_pool():
         except Exception as e:
             logger.error(f"Error closing global database pool: {e}")
             _pool = None
+
 
 # Register cleanup at exit
 def _cleanup_pool_sync():
@@ -404,7 +437,9 @@ def _cleanup_pool_sync():
         except Exception as e:
             logger.warning(f"Could not cleanly close pool at exit: {e}")
 
+
 atexit.register(_cleanup_pool_sync)
+
 
 # Asynchronous usage example
 async def main():
@@ -418,4 +453,5 @@ async def main():
 
 if __name__ == "__main__":
     import asyncio
+
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- make SSL connections optional by adding a `validate_ssl` flag to the connection pool
- read the `VALIDATE_SSL` env var and disable cert verification when false

## Testing
- `black secure_pool.py settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'quart.wrappers'; 'quart' is not a package)*
- `flake8 secure_pool.py settings.py` *(fails: secure_pool.py:7:1: F401 'dataclasses.field' imported but unused and 45 more)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b8118160832dafc8c66349aff37f