### PR TITLE
Allow TMDB images in Next.js config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'image.tmdb.org',
+        pathname: '/**',
+      },
+    ],
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow `image.tmdb.org` in Next.js remote image domains

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'quart.wrappers'; 'quart' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f1487930832d908321e4262b26a7